### PR TITLE
Adapters: use each system's documented bulk-ingest path

### DIFF
--- a/oban-bench/lib/oban_bench/long_horizon.ex
+++ b/oban-bench/lib/oban_bench/long_horizon.ex
@@ -39,6 +39,12 @@ defmodule ObanBench.LongHorizon do
     worker_count = env_int("WORKER_COUNT", 32)
     work_ms = env_int("JOB_WORK_MS", 1)
     payload_bytes = env_int("JOB_PAYLOAD_BYTES", 256)
+    # Batch size for Oban's documented bulk-insert API
+    # (`Oban.insert_all/2`: https://hexdocs.pm/oban/Oban.html#insert_all/2 —
+    # accepts a list of changesets, issues a single multi-row INSERT).
+    # Default 1 keeps existing row-by-row behaviour.
+    producer_batch_max = max(1, env_int("PRODUCER_BATCH_MAX", 1))
+    producer_batch_ms = max(1, env_int("PRODUCER_BATCH_MS", 10))
 
     db_name =
       System.get_env("DATABASE_URL", "")
@@ -75,8 +81,17 @@ defmodule ObanBench.LongHorizon do
 
     _producer =
       spawn(fn ->
-        producer_loop(producer_mode, producer_rate, target_depth, padding, producer_rate_control_file)
+        producer_loop(
+          producer_mode,
+          producer_rate,
+          target_depth,
+          padding,
+          producer_rate_control_file,
+          producer_batch_max,
+          producer_batch_ms
+        )
       end)
+
     _sampler = spawn(fn -> sampler_loop(sample_every_s) end)
     _depth = spawn(fn -> depth_loop() end)
 
@@ -84,64 +99,186 @@ defmodule ObanBench.LongHorizon do
     Process.sleep(:infinity)
   end
 
-  defp producer_loop("fixed", rate, _target_depth, _padding, _control_file) when rate <= 0, do: :ok
+  defp producer_loop("fixed", rate, _target_depth, _padding, _control_file, _batch_max, _batch_ms)
+       when rate <= 0,
+       do: :ok
 
-  defp producer_loop(mode, rate, target_depth, padding, control_file) do
-    producer_step(0, mode, rate, target_depth, padding, control_file)
+  defp producer_loop(mode, rate, target_depth, padding, control_file, batch_max, batch_ms) do
+    producer_step(
+      0,
+      mode,
+      rate,
+      target_depth,
+      padding,
+      control_file,
+      batch_max,
+      batch_ms,
+      0.0,
+      System.monotonic_time(:millisecond)
+    )
   end
 
-  defp producer_step(seq, mode, base_rate, target_depth, padding, control_file) do
-    should_insert =
+  # `rate_credit` accumulates fractional rate*dt while we wait for the
+  # next batch boundary; we dispatch up to `batch_max` jobs per
+  # `Oban.insert_all/2` call when the credit ≥ 1.
+  defp producer_step(
+         seq,
+         mode,
+         base_rate,
+         target_depth,
+         padding,
+         control_file,
+         batch_max,
+         batch_ms,
+         rate_credit,
+         last_credit_tick_ms
+       ) do
+    {batch_count, new_credit, new_tick_ms} =
       case mode do
         "depth-target" ->
           :ets.insert(:long_horizon_state, {:producer_target_rate, 0.0})
 
-          case :ets.lookup(:long_horizon_state, :queue_depth) do
-            [{:queue_depth, depth}] when depth >= target_depth ->
-              Process.sleep(50)
-              false
+          remaining =
+            case :ets.lookup(:long_horizon_state, :queue_depth) do
+              [{:queue_depth, depth}] -> max(0, target_depth - depth)
+              _ -> target_depth
+            end
 
-            _ ->
-              true
+          if remaining <= 0 do
+            Process.sleep(50)
+            {0, rate_credit, last_credit_tick_ms}
+          else
+            count = min(batch_max, remaining)
+            {count, rate_credit, last_credit_tick_ms}
           end
 
         _ ->
           current_rate = read_producer_rate(base_rate, control_file)
           :ets.insert(:long_horizon_state, {:producer_target_rate, current_rate * 1.0})
 
-          if current_rate <= 0 do
-            Process.sleep(100)
-            false
-          else
-            Process.sleep(max(1, div(1000, current_rate)))
-            true
+          cond do
+            current_rate <= 0 ->
+              Process.sleep(100)
+              {0, 0.0, System.monotonic_time(:millisecond)}
+
+            batch_max <= 1 ->
+              # Original single-row pacing.
+              Process.sleep(max(1, div(1000, current_rate)))
+              {1, rate_credit, last_credit_tick_ms}
+
+            true ->
+              # Sleep for batch_ms, accumulate rate*dt jobs of credit,
+              # dispatch up to batch_max.
+              now_ms = System.monotonic_time(:millisecond)
+              elapsed_ms = now_ms - last_credit_tick_ms
+              sleep_for = batch_ms - elapsed_ms
+              if sleep_for > 0, do: Process.sleep(sleep_for)
+              now_ms2 = System.monotonic_time(:millisecond)
+              dt_s = (now_ms2 - last_credit_tick_ms) / 1000.0
+              credit = rate_credit + current_rate * dt_s
+
+              if credit < 1.0 do
+                {0, credit, now_ms2}
+              else
+                whole = trunc(credit)
+                count = min(batch_max, whole)
+                {count, credit - count, now_ms2}
+              end
           end
       end
 
-    if not should_insert do
-      producer_step(seq, mode, base_rate, target_depth, padding, control_file)
-    else
-      result =
-        try do
-          Oban.insert(LongHorizonWorker.new(%{seq: seq, padding: padding}))
-        rescue
-          ArgumentError -> :stopping
-          RuntimeError -> :stopping
-        catch
-          :exit, _reason -> :stopping
+    case batch_count do
+      0 ->
+        producer_step(
+          seq,
+          mode,
+          base_rate,
+          target_depth,
+          padding,
+          control_file,
+          batch_max,
+          batch_ms,
+          new_credit,
+          new_tick_ms
+        )
+
+      _ ->
+        result = insert_batch(seq, batch_count, padding, batch_max)
+
+        case result do
+          :ok ->
+            :ets.update_counter(:long_horizon_state, :enqueued, batch_count)
+
+            producer_step(
+              seq + batch_count,
+              mode,
+              base_rate,
+              target_depth,
+              padding,
+              control_file,
+              batch_max,
+              batch_ms,
+              new_credit,
+              new_tick_ms
+            )
+
+          :stopping ->
+            :ok
+
+          :error ->
+            # Skip this attempt to avoid a tight retry loop, then continue
+            # with the same seq budget so we don't drop sequence ids.
+            producer_step(
+              seq + batch_count,
+              mode,
+              base_rate,
+              target_depth,
+              padding,
+              control_file,
+              batch_max,
+              batch_ms,
+              new_credit,
+              new_tick_ms
+            )
         end
+    end
+  end
 
-      case result do
-        {:ok, _} ->
-          :ets.update_counter(:long_horizon_state, :enqueued, 1)
-          producer_step(seq + 1, mode, base_rate, target_depth, padding, control_file)
-
-        :stopping ->
-          :ok
-
-        _ ->
-          producer_step(seq + 1, mode, base_rate, target_depth, padding, control_file)
+  # batch_max == 1 → preserve the original Oban.insert/1 wire path.
+  # batch_max > 1 → Oban.insert_all/2 (documented bulk path).
+  defp insert_batch(seq, 1, padding, batch_max) when batch_max <= 1 do
+    try do
+      case Oban.insert(LongHorizonWorker.new(%{seq: seq, padding: padding})) do
+        {:ok, _} -> :ok
+        _ -> :error
       end
+    rescue
+      ArgumentError -> :stopping
+      RuntimeError -> :stopping
+    catch
+      :exit, _reason -> :stopping
+    end
+  end
+
+  defp insert_batch(seq, batch_count, padding, _batch_max) do
+    changesets =
+      for i <- 0..(batch_count - 1) do
+        LongHorizonWorker.new(%{seq: seq + i, padding: padding})
+      end
+
+    try do
+      # Documented bulk path: `Oban.insert_all/2`
+      # https://hexdocs.pm/oban/Oban.html#insert_all/2 — issues a single
+      # multi-row INSERT for the supplied changesets.
+      case Oban.insert_all(changesets) do
+        jobs when is_list(jobs) -> :ok
+        _ -> :error
+      end
+    rescue
+      ArgumentError -> :stopping
+      RuntimeError -> :stopping
+    catch
+      :exit, _reason -> :stopping
     end
   end
 
@@ -170,7 +307,9 @@ defmodule ObanBench.LongHorizon do
         end
 
       case depth do
-        :stopping -> :ok
+        :stopping ->
+          :ok
+
         value ->
           :ets.insert(:long_horizon_state, {:queue_depth, value})
           depth_loop()
@@ -197,6 +336,7 @@ defmodule ObanBench.LongHorizon do
     [{:enqueued, enq}] = :ets.lookup(:long_horizon_state, :enqueued)
     [{:completed, cmp}] = :ets.lookup(:long_horizon_state, :completed)
     [{:queue_depth, depth}] = :ets.lookup(:long_horizon_state, :queue_depth)
+
     [{:producer_target_rate, producer_target_rate}] =
       :ets.lookup(:long_horizon_state, :producer_target_rate)
 
@@ -270,7 +410,9 @@ defmodule ObanBench.LongHorizon do
   # right replica without per-subprocess state.
   defp instance_id do
     case System.get_env("BENCH_INSTANCE_ID") do
-      nil -> 0
+      nil ->
+        0
+
       raw ->
         case Integer.parse(raw) do
           {n, ""} -> n

--- a/pgque-bench/main.py
+++ b/pgque-bench/main.py
@@ -218,6 +218,13 @@ async def scenario_long_horizon() -> None:
     worker_count = env_int("WORKER_COUNT", 32)
     payload_bytes = env_int("JOB_PAYLOAD_BYTES", 256)
     work_ms = env_int("JOB_WORK_MS", 1)
+    # Batch size for the documented bulk-insert API
+    # (`pgque.send_batch(queue, type, payloads text[])`, vendored at
+    # vendor/pgque/sql/pgque-api/send.sql). Default 1 keeps existing
+    # row-by-row behaviour; the bench harness opts in to larger batches
+    # via the env var.
+    producer_batch_max = max(1, env_int("PRODUCER_BATCH_MAX", 1))
+    producer_batch_ms = max(1, env_int("PRODUCER_BATCH_MS", 10))
 
     db_name = database_url().rsplit("/", 1)[-1]
 
@@ -291,10 +298,18 @@ async def scenario_long_horizon() -> None:
         nonlocal enqueued, current_producer_target_rate
         seq = 0
         next_t = loop.time()
+        # Fixed-rate accounting: instead of sleeping 1/rate per job (which
+        # caps single-row throughput by event-loop scheduling overhead),
+        # accumulate a fractional credit budget and dispatch up to
+        # producer_batch_max jobs per send_batch call.
+        rate_credit = 0.0
+        last_credit_tick = loop.time()
         while not shutdown.is_set():
             if producer_mode == "depth-target":
                 current_producer_target_rate = 0.0
-                if queue_depth >= target_depth:
+                remaining = max(0, target_depth - queue_depth)
+                batch_count = min(producer_batch_max, remaining)
+                if batch_count <= 0:
                     await asyncio.sleep(0.05)
                     continue
                 next_t = loop.time()
@@ -303,30 +318,75 @@ async def scenario_long_horizon() -> None:
                 current_producer_target_rate = float(effective_rate)
                 if effective_rate <= 0:
                     next_t = loop.time()
+                    rate_credit = 0.0
+                    last_credit_tick = loop.time()
                     await asyncio.sleep(0.1)
                     continue
-                next_t = max(next_t + (1.0 / effective_rate), loop.time())
-                sleep_for = next_t - loop.time()
-                if sleep_for > 0:
-                    await asyncio.sleep(sleep_for)
-            payload = json.dumps(
-                {
-                    "seq": seq,
-                    "created_at": _now_iso(),
-                    "padding": payload_padding,
-                }
-            )
+                if producer_batch_max <= 1:
+                    # Preserve original behaviour: precise inter-arrival pacing.
+                    next_t = max(next_t + (1.0 / effective_rate), loop.time())
+                    sleep_for = next_t - loop.time()
+                    if sleep_for > 0:
+                        await asyncio.sleep(sleep_for)
+                    batch_count = 1
+                else:
+                    # Batching path: sleep for producer_batch_ms, accumulate
+                    # rate * dt jobs of credit, dispatch up to batch_max.
+                    period_s = producer_batch_ms / 1000.0
+                    sleep_for = max(0.0, period_s - (loop.time() - last_credit_tick))
+                    if sleep_for > 0:
+                        await asyncio.sleep(sleep_for)
+                    now = loop.time()
+                    rate_credit += effective_rate * (now - last_credit_tick)
+                    last_credit_tick = now
+                    if rate_credit < 1.0:
+                        continue
+                    batch_count = min(producer_batch_max, int(rate_credit))
+                    rate_credit -= batch_count
+
+            # Build the batch payloads — one JSON-encoded text payload per job.
+            payloads: list[str] = []
+            for _ in range(batch_count):
+                payloads.append(
+                    json.dumps(
+                        {
+                            "seq": seq,
+                            "created_at": _now_iso(),
+                            "padding": payload_padding,
+                        }
+                    )
+                )
+                seq += 1
             insert_started = time.monotonic()
             try:
-                async with producer_conn.cursor() as cur:
-                    await cur.execute(
-                        "SELECT pgque.send(%s, %s::text)", (QUEUE_NAME, payload)
-                    )
-                producer_latencies_ms.append(
-                    ((time.monotonic()), max(0.0, (time.monotonic() - insert_started) * 1000.0))
-                )
-                enqueued += 1
-                seq += 1
+                if batch_count == 1:
+                    # Single-row path: keep using send() so the wire profile
+                    # for PRODUCER_BATCH_MAX=1 runs is unchanged from before.
+                    async with producer_conn.cursor() as cur:
+                        await cur.execute(
+                            "SELECT pgque.send(%s, %s::text)",
+                            (QUEUE_NAME, payloads[0]),
+                        )
+                else:
+                    # Documented bulk path:
+                    # `pgque.send_batch(queue, type, payloads text[])` —
+                    # see vendor/pgque/sql/pgque-api/send.sql lines 101-115.
+                    # Default type 'default' matches the no-type send()
+                    # overloads used elsewhere in this adapter.
+                    async with producer_conn.cursor() as cur:
+                        await cur.execute(
+                            "SELECT pgque.send_batch(%s, %s, %s::text[])",
+                            (QUEUE_NAME, "default", payloads),
+                        )
+                elapsed_ms = max(0.0, (time.monotonic() - insert_started) * 1000.0)
+                # Record per-message latency (call-cost / batch-count) so the
+                # producer_*_ms percentiles remain comparable to the row-by-row
+                # baseline despite amortisation.
+                sample_ts = time.monotonic()
+                per_msg_ms = elapsed_ms / max(batch_count, 1)
+                for _ in range(batch_count):
+                    producer_latencies_ms.append((sample_ts, per_msg_ms))
+                enqueued += batch_count
             except Exception as exc:
                 print(f"[pgque] producer send failed: {exc}", file=sys.stderr)
                 await asyncio.sleep(0.05)

--- a/procrastinate-bench/main.py
+++ b/procrastinate-bench/main.py
@@ -278,6 +278,12 @@ async def scenario_long_horizon() -> None:
     target_depth = env_int("TARGET_DEPTH", 1000)
     worker_count = env_int("WORKER_COUNT", 32)
     work_ms = env_int("JOB_WORK_MS", 1)
+    # Batch size for procrastinate's documented bulk-defer API
+    # (`Task.batch_defer_async(*task_kwargs)` →
+    # `JobManager.batch_defer_jobs_async`, which builds a single
+    # multi-row INSERT). Default 1 keeps existing row-by-row behaviour.
+    producer_batch_max = max(1, env_int("PRODUCER_BATCH_MAX", 1))
+    producer_batch_ms = max(1, env_int("PRODUCER_BATCH_MS", 10))
 
     queue = "procrastinate_longhorizon_bench"
     # Parse the URL path so query params like ?sslmode=disable don't leak
@@ -360,10 +366,14 @@ async def scenario_long_horizon() -> None:
             seq = 0
             deferrer = long_horizon_task.configure(queue=queue)
             next_t = loop.time()
+            rate_credit = 0.0
+            last_credit_tick = loop.time()
             while not shutdown.is_set():
                 if producer_mode == "depth-target":
                     current_producer_target_rate = 0.0
-                    if queue_depth >= target_depth:
+                    remaining = max(0, target_depth - queue_depth)
+                    batch_count = min(producer_batch_max, remaining)
+                    if batch_count <= 0:
                         await asyncio.sleep(0.05)
                         continue
                     next_t = loop.time()
@@ -372,19 +382,46 @@ async def scenario_long_horizon() -> None:
                     current_producer_target_rate = float(effective_rate)
                     if effective_rate <= 0:
                         next_t = loop.time()
+                        rate_credit = 0.0
+                        last_credit_tick = loop.time()
                         await asyncio.sleep(0.1)
                         continue
-                    next_t = max(next_t + (1.0 / effective_rate), loop.time())
-                    sleep_for = next_t - loop.time()
-                    if sleep_for > 0:
-                        await asyncio.sleep(sleep_for)
+                    if producer_batch_max <= 1:
+                        next_t = max(next_t + (1.0 / effective_rate), loop.time())
+                        sleep_for = next_t - loop.time()
+                        if sleep_for > 0:
+                            await asyncio.sleep(sleep_for)
+                        batch_count = 1
+                    else:
+                        period_s = producer_batch_ms / 1000.0
+                        sleep_for = max(0.0, period_s - (loop.time() - last_credit_tick))
+                        if sleep_for > 0:
+                            await asyncio.sleep(sleep_for)
+                        now = loop.time()
+                        rate_credit += effective_rate * (now - last_credit_tick)
+                        last_credit_tick = now
+                        if rate_credit < 1.0:
+                            continue
+                        batch_count = min(producer_batch_max, int(rate_credit))
+                        rate_credit -= batch_count
                 try:
-                    await deferrer.defer_async(
-                        seq=seq,
-                        created_at_iso=_now_iso(),
-                    )
-                    enqueued += 1
-                    seq += 1
+                    if batch_count == 1:
+                        await deferrer.defer_async(
+                            seq=seq,
+                            created_at_iso=_now_iso(),
+                        )
+                    else:
+                        # Documented bulk path: `Task.batch_defer_async`
+                        # (procrastinate.tasks.Task line 143). Issues a single
+                        # multi-row INSERT via JobManager.batch_defer_jobs_async.
+                        # Docs: https://procrastinate.readthedocs.io/en/stable/howto/advanced/batch.html
+                        kwargs_list = [
+                            {"seq": seq + i, "created_at_iso": _now_iso()}
+                            for i in range(batch_count)
+                        ]
+                        await deferrer.batch_defer_async(*kwargs_list)
+                    enqueued += batch_count
+                    seq += batch_count
                 except Exception as exc:
                     print(
                         f"[procrastinate] producer insert failed: {exc}",

--- a/river-bench/main.go
+++ b/river-bench/main.go
@@ -528,6 +528,18 @@ func runLongHorizon(ctx context.Context, pool *pgxpool.Pool, workerCount int) {
 	producerMode := envOrDefault("PRODUCER_MODE", "fixed")
 	targetDepth := envInt("TARGET_DEPTH", 1000)
 	sampleEveryS := envInt("SAMPLE_EVERY_S", 10)
+	// Batch size for River's documented bulk-insert API
+	// (Client.InsertManyFast: https://pkg.go.dev/github.com/riverqueue/river#Client.InsertManyFast,
+	// docs: https://riverqueue.com/docs/batch-job-insertion). Uses Postgres
+	// COPY under the hood. Default 1 keeps existing row-by-row behaviour.
+	producerBatchMax := envInt("PRODUCER_BATCH_MAX", 1)
+	if producerBatchMax < 1 {
+		producerBatchMax = 1
+	}
+	producerBatchMs := envInt("PRODUCER_BATCH_MS", 10)
+	if producerBatchMs < 1 {
+		producerBatchMs = 1
+	}
 	if sampleEveryS <= 0 {
 		log.Fatalf("SAMPLE_EVERY_S must be > 0; got %d", sampleEveryS)
 	}
@@ -590,6 +602,9 @@ func runLongHorizon(ctx context.Context, pool *pgxpool.Pool, workerCount int) {
 	go func() {
 		defer producerWG.Done()
 		var seq int64
+		// Fractional credit budget for fixed-rate batching.
+		var rateCredit float64
+		lastCreditTick := time.Now()
 		for {
 			select {
 			case <-shutdown:
@@ -597,29 +612,78 @@ func runLongHorizon(ctx context.Context, pool *pgxpool.Pool, workerCount int) {
 			default:
 			}
 
+			batchCount := 0
 			if producerMode == "depth-target" {
 				producerTargetRate.Store(0)
-				if state.queueDepth.Load() >= int64(targetDepth) {
+				remaining := int64(targetDepth) - state.queueDepth.Load()
+				if remaining <= 0 {
 					time.Sleep(50 * time.Millisecond)
 					continue
+				}
+				batchCount = int(remaining)
+				if batchCount > producerBatchMax {
+					batchCount = producerBatchMax
 				}
 			} else {
 				currentRate := readProducerRate(producerRate)
 				producerTargetRate.Store(int64(currentRate))
 				if currentRate <= 0 {
+					rateCredit = 0
+					lastCreditTick = time.Now()
 					time.Sleep(100 * time.Millisecond)
 					continue
 				}
-				time.Sleep(time.Second / time.Duration(currentRate))
+				if producerBatchMax <= 1 {
+					// Original single-row pacing.
+					time.Sleep(time.Second / time.Duration(currentRate))
+					batchCount = 1
+				} else {
+					// Sleep for producerBatchMs, accumulate rate*dt jobs of
+					// credit, dispatch up to batchMax.
+					period := time.Duration(producerBatchMs) * time.Millisecond
+					sleepFor := period - time.Since(lastCreditTick)
+					if sleepFor > 0 {
+						time.Sleep(sleepFor)
+					}
+					now := time.Now()
+					rateCredit += float64(currentRate) * now.Sub(lastCreditTick).Seconds()
+					lastCreditTick = now
+					if rateCredit < 1.0 {
+						continue
+					}
+					batchCount = int(rateCredit)
+					if batchCount > producerBatchMax {
+						batchCount = producerBatchMax
+					}
+					rateCredit -= float64(batchCount)
+				}
 			}
 
-			_, err := client.Insert(ctx, LongHorizonArgs{Seq: seq, Padding: padding}, nil)
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "[river] producer insert failed: %v\n", err)
-				continue
+			if batchCount == 1 {
+				_, err := client.Insert(ctx, LongHorizonArgs{Seq: seq, Padding: padding}, nil)
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "[river] producer insert failed: %v\n", err)
+					continue
+				}
+				state.enqueued.Add(1)
+				seq++
+			} else {
+				// Documented bulk path: Client.InsertManyFast (Postgres COPY).
+				// https://pkg.go.dev/github.com/riverqueue/river#Client.InsertManyFast
+				params := make([]river.InsertManyParams, 0, batchCount)
+				for i := 0; i < batchCount; i++ {
+					params = append(params, river.InsertManyParams{
+						Args: LongHorizonArgs{Seq: seq + int64(i), Padding: padding},
+					})
+				}
+				_, err := client.InsertManyFast(ctx, params)
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "[river] producer InsertManyFast failed: %v\n", err)
+					continue
+				}
+				state.enqueued.Add(uint64(batchCount))
+				seq += int64(batchCount)
 			}
-			state.enqueued.Add(1)
-			seq++
 		}
 	}()
 


### PR DESCRIPTION
## Summary

Closes [#5](https://github.com/hardbyte/postgresql-job-queue-benchmarking/issues/5).

The 2026-05-01 worker-scaling matrix was structurally asymmetric: awa hit 4,319 jobs/s at 128 workers because its adapter honors `PRODUCER_BATCH_MAX` and uses `enqueue_params_batch` (multi-row INSERT), while the rest of the adapters' producers were row-by-row. This PR switches every adapter to its system's *documented* bulk-ingest API so a re-run of the matrix is fair-bulk-vs-bulk.

Each producer now:

1. Reads `PRODUCER_BATCH_MAX` from env (default `1` for adapters that were row-by-row, so existing recorded behaviour is unchanged unless the harness explicitly opts in).
2. Builds a batch of up to `PRODUCER_BATCH_MAX` jobs.
3. Calls the documented bulk API once per batch.

Producer mode (`fixed` / `depth-target`), `TARGET_DEPTH` interaction, and metric emissions (`enqueue_rate`, `producer_p*_ms`, `producer_call_p*_ms` where applicable) are unchanged. Per-call latency is recorded as `elapsed / batch_count` so percentiles stay comparable across batch sizes.

## Per-adapter before / after

| Adapter | Before | After (when `PRODUCER_BATCH_MAX > 1`) | Documented path |
|---|---|---|---|
| `awa-bench` | `enqueue_params_batch` (multi-row INSERT) | unchanged — already wired, default `PRODUCER_BATCH_MAX=128` | already documented in awa |
| `pgboss-bench` | `boss.insert(QUEUE_NAME, jobs)` (array) | unchanged — already using documented bulk path, default `PRODUCER_BATCH_MAX=128` | https://github.com/timgit/pg-boss/blob/master/docs/readme.md#insertname-jobs |
| `pgmq-bench` | `pgmq.send_batch(queue, [msgs])` | unchanged — already using documented bulk path, default `PRODUCER_BATCH_MAX=128` | https://tembo-io.github.io/pgmq/api/sql/functions/#send_batch |
| `pgque-bench` | row-by-row `pgque.send(queue, payload)` | `pgque.send_batch(queue, type, payloads text[])` | vendored at `pgque-bench/vendor/pgque/sql/pgque-api/send.sql` lines 86-115 (alpha3+3b75f58) |
| `procrastinate-bench` | row-by-row `Task.defer_async(...)` | `Task.batch_defer_async(*task_kwargs)` (single multi-row INSERT via `JobManager.batch_defer_jobs_async`) | https://procrastinate.readthedocs.io/en/stable/howto/advanced/batch.html |
| `river-bench` | row-by-row `Client.Insert` | `Client.InsertManyFast` (Postgres COPY) | https://pkg.go.dev/github.com/riverqueue/river#Client.InsertManyFast — https://riverqueue.com/docs/batch-job-insertion |
| `oban-bench` | row-by-row `Oban.insert/1` | `Oban.insert_all/2` (single multi-row INSERT) | https://hexdocs.pm/oban/Oban.html#insert_all/2 |

## Adapters left unchanged

None. Every system in the matrix has a documented bulk API and now uses it.

## Smoke tests run

For each adapter that was changed, ran a 30s harness run with `PRODUCER_BATCH_MAX=100` and confirmed `enqueue_rate` is non-zero in `raw.csv` and the JSON-on-stdout descriptor + sample contract is unchanged:

```
PRODUCER_BATCH_MAX=100 uv run python long_horizon.py run \
    --systems <name> --replicas 1 --worker-count 4 --producer-rate 5000 \
    --producer-mode depth-target --target-depth 1000 \
    --phase warmup=warmup:15s --phase clean=clean:15s
```

- pgque: ~450-735 jobs/s sustained (warmup), drops to ~450 jobs/s in clean
- procrastinate: ~160-294 jobs/s
- river: ~93-249 jobs/s (4 workers x 1ms work caps drain rate)
- oban: ~228-374 jobs/s

These are smoke-test rates with 4 workers and short windows; they are not headline numbers. The fair-bulk-vs-bulk re-run of the worker-scaling matrix will produce those.

## Build / lint

- `cargo` not invoked (no Rust changed).
- `go build ./...` clean for `river-bench` (`go vet` clean).
- `mix compile --warnings-as-errors` clean for `oban-bench`; `mix format` applied.
- Python adapters: `python -m py_compile` clean.

## Not in scope

- The `awa-ui/frontend` plot generation isn't touched.
- `CONTRIBUTING_ADAPTERS.md`'s sample schema is unchanged.
- The matrix re-run itself isn't started here — that's the parent task once this lands.