### PR TITLE
feat: pg_ash-style wait-event sampling for the harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,24 @@ that are incompatible with throughput sampling).
 | `retry_storm` | Drive a high concurrent retry rate; verify no duplicate completions. |
 | `priority_starvation` | Mix high- and low-priority work; verify low priority eventually runs (priority aging). |
 
+## Wait-event sampling
+
+Throughput, latency, and bloat answer *that* one system is slower than
+another. **Wait events** answer *why* — the postgres-side reason a
+system is bottlenecked, not just whether it is. The harness samples
+`pg_stat_activity` once per second from a dedicated connection and
+aggregates non-idle backend snapshots into a per-phase histogram of
+`(wait_event_type, wait_event)`. Same shape as
+[pg_ash](https://github.com/NikolayS/pg_ash) produces, implemented
+inside the harness so we don't have to swap the postgres image.
+
+Output lands in `raw.csv` (`subject_kind=wait_event`), `summary.json`
+(top-10 events per phase plus `total_active_samples`), and a stacked
+bar plot per system in `index.html`. On by default at 1 s cadence;
+opt out with `--no-wait-events` or tune via
+`--wait-event-sample-every <seconds>`. Primer with the common event
+types and how to read the stack: [`docs/wait-events.md`](docs/wait-events.md).
+
 ## Repo layout
 
 ```

--- a/bench_harness/config.py
+++ b/bench_harness/config.py
@@ -67,6 +67,13 @@ class CliConfig(BaseModel):
     # by replicas before passing).
     replicas: Annotated[int, Field(ge=1)] = 1
 
+    # ── Wait-event sampling ────────────────────────────────────────────
+    # pg_ash-style: poll pg_stat_activity periodically into a per-phase
+    # (event_type, event) histogram. Default ON; overhead is negligible
+    # (< 0.1% of one core at 1 s cadence). See bench_harness/wait_events.py.
+    wait_events: bool = True
+    wait_event_sample_every: Annotated[float, Field(gt=0.0)] = 1.0
+
     @field_validator("scenario")
     @classmethod
     def _scenario_must_be_known(cls, v: str | None) -> str | None:
@@ -130,6 +137,8 @@ class CliConfig(BaseModel):
             worker_count=args.worker_count,
             high_load_multiplier=args.high_load_multiplier,
             replicas=args.replicas,
+            wait_events=getattr(args, "wait_events", True),
+            wait_event_sample_every=getattr(args, "wait_event_sample_every", 1.0),
         )
 
 

--- a/bench_harness/orchestrator.py
+++ b/bench_harness/orchestrator.py
@@ -49,6 +49,7 @@ from .report import write_interactive_report
 from .replica_pool import ReplicaPool
 from .sample import Sample
 from .versions import capture_adapter_revision
+from .wait_events import WaitEventSampler
 from .writers import (
     RawCsvWriter,
     build_manifest,
@@ -450,6 +451,74 @@ def _check_descriptor_drift(manifest: AdapterManifest, descriptor: dict) -> None
 # ────────────────────────────────────────────────────────────────────────
 
 
+def _emit_wait_event_snapshot(
+    *,
+    sampler: WaitEventSampler,
+    phase: Phase,
+    run_id: str,
+    system: str,
+    bench_start: float,
+    out_queue: "queue.Queue[Sample]",
+) -> None:
+    """Drain the sampler's counts for ``phase`` and queue them for raw.csv.
+
+    Emits one Sample per ``(event_type, event)`` bucket plus a
+    ``total_active_samples`` denominator so consumers can compute
+    percentages without re-summing the histogram. Subject_kind is
+    ``wait_event`` — the discriminator for the new subject_kind so
+    downstream code can keep these rows distinct from adapter / table /
+    cluster metrics.
+
+    The harness writes these rows from a different code path than the
+    adapter stdout tailer (which produces ``subject_kind=adapter``).
+    Keeping the new ``wait_event`` kind makes that distinction explicit
+    in raw.csv so analyses can include or exclude wait-event rows
+    without inferring source from the metric name.
+    """
+    from .sample import now_iso
+
+    rows, total_active = sampler.snapshot(phase.label)
+    elapsed = round(time.time() - bench_start, 3)
+    sampled_at = now_iso()
+    for row in rows:
+        subject = f"{row.wait_event_type}:{row.wait_event}"
+        out_queue.put(
+            Sample(
+                run_id=run_id,
+                system=system,
+                instance_id=0,
+                elapsed_s=elapsed,
+                sampled_at=sampled_at,
+                phase_label=phase.label,
+                phase_type=phase.type.value,
+                subject_kind="wait_event",
+                subject=subject,
+                metric="wait_event_count",
+                value=float(row.count),
+                window_s=float(phase.duration_s),
+            )
+        )
+    # Always emit the denominator — even if zero — so a zero-active phase
+    # is recoverable from raw.csv (otherwise it would look identical to a
+    # phase the sampler didn't observe at all).
+    out_queue.put(
+        Sample(
+            run_id=run_id,
+            system=system,
+            instance_id=0,
+            elapsed_s=elapsed,
+            sampled_at=sampled_at,
+            phase_label=phase.label,
+            phase_type=phase.type.value,
+            subject_kind="wait_event",
+            subject="__total__",
+            metric="total_active_samples",
+            value=float(total_active),
+            window_s=float(phase.duration_s),
+        )
+    )
+
+
 def _drain_loop(
     out_queue: "queue.Queue[Sample]", writer: RawCsvWriter, stop_event: threading.Event
 ) -> None:
@@ -483,6 +552,8 @@ def run_one_system(
     worker_count: int,
     high_load_multiplier: float,
     replicas: int = 1,
+    wait_events_enabled: bool = True,
+    wait_event_sample_every_s: float = 1.0,
 ) -> dict:
     entry = ADAPTERS[system]
     manifest = AdapterManifest.load(entry.bench_dir)
@@ -562,6 +633,20 @@ def run_one_system(
     )
     daemon.start()
 
+    # Wait-event sampler — pg_ash-style ASH from the harness side. Polls
+    # pg_stat_activity once per second by default, aggregates non-idle
+    # rows into a (event_type, event) histogram, snapshot drained at
+    # each phase boundary into raw.csv with subject_kind='wait_event'.
+    # See bench_harness/wait_events.py for the design.
+    wait_sampler: WaitEventSampler | None = None
+    if wait_events_enabled:
+        wait_sampler = WaitEventSampler(
+            database_url=pg_url(manifest.db_name),
+            get_phase=tracker.get,
+            sample_every_s=wait_event_sample_every_s,
+        )
+        wait_sampler.start()
+
     registry = default_registry()
     phase_state: dict[str, object] = {
         "producer_rate_control_file": str(control_file),
@@ -595,9 +680,23 @@ def run_one_system(
                 registry.exit(runtime)
                 # Phase-boundary snapshot: pgstattuple / pgstatindex.
                 daemon.phase_boundary_snapshot()
+                # Wait-event histogram snapshot for this phase. Drains
+                # the per-phase counter from the sampler so the next
+                # phase's counts don't pile on top.
+                if wait_sampler is not None:
+                    _emit_wait_event_snapshot(
+                        sampler=wait_sampler,
+                        phase=phase,
+                        run_id=run_id,
+                        system=system,
+                        bench_start=bench_start,
+                        out_queue=out_queue,
+                    )
     finally:
         daemon.stop()
         daemon.join(timeout=5.0)
+        if wait_sampler is not None:
+            wait_sampler.stop()
         pool.stop_all()
         shutil.rmtree(control_dir, ignore_errors=True)
 
@@ -662,6 +761,8 @@ def drive(
     high_load_multiplier: float,
     replicas: int,
     cli_args: list[str],
+    wait_events_enabled: bool = True,
+    wait_event_sample_every_s: float = 1.0,
 ) -> Path:
     unknown = [s for s in systems if s not in ADAPTERS]
     if unknown:
@@ -755,6 +856,8 @@ def drive(
                 worker_count=worker_count,
                 high_load_multiplier=high_load_multiplier,
                 replicas=replicas,
+                wait_events_enabled=wait_events_enabled,
+                wait_event_sample_every_s=wait_event_sample_every_s,
             )
             # Merge the runtime descriptor the adapter emitted with the
             # harness-proven revision block (git SHA / submodule SHA /
@@ -918,6 +1021,31 @@ def _add_run_arguments(parser: argparse.ArgumentParser) -> None:
         "aggregate. Divide --producer-rate by --replicas to hold total "
         "offered load constant across replica counts.",
     )
+    # Wait-event sampling — pg_ash-style ASH. ON by default; the overhead
+    # is a single short SELECT against pg_stat_activity per second
+    # (< 0.1% of one core). See docs/wait-events.md.
+    wait_group = parser.add_mutually_exclusive_group()
+    wait_group.add_argument(
+        "--no-wait-events",
+        dest="wait_events",
+        action="store_false",
+        help="Disable wait-event sampling (pg_stat_activity polling). "
+        "Default is on.",
+    )
+    wait_group.add_argument(
+        "--wait-events",
+        dest="wait_events",
+        action="store_true",
+        help="Enable wait-event sampling (default).",
+    )
+    parser.set_defaults(wait_events=True)
+    parser.add_argument(
+        "--wait-event-sample-every",
+        type=float,
+        default=1.0,
+        help="Wait-event sampling cadence in seconds (default 1.0). "
+        "Overhead is a single short SELECT per tick.",
+    )
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -998,6 +1126,8 @@ def _cmd_run(args: argparse.Namespace) -> int:
         high_load_multiplier=config.high_load_multiplier,
         replicas=config.replicas,
         cli_args=list(sys.argv),
+        wait_events_enabled=config.wait_events,
+        wait_event_sample_every_s=config.wait_event_sample_every,
     )
     return 0
 

--- a/bench_harness/plots.py
+++ b/bench_harness/plots.py
@@ -477,6 +477,145 @@ def render_plot(
     plt.close(fig)
 
 
+def render_wait_events_clean_phase(
+    rows: list[dict],
+    *,
+    systems: list[str],
+    phases: list[Phase],
+    out_dir: Path,
+    system_meta: SystemMeta | None = None,
+    top_n: int = 5,
+) -> Path | None:
+    """Stacked-bar chart per system showing the top-N wait-event types as a
+    fraction of total active-backend samples during the clean phase.
+
+    Picks the *first* clean phase in the run. Each system gets one bar;
+    each segment is one wait-event type. Segments coloured from the
+    standard palette. If there is no clean phase, or no wait-event rows
+    landed in raw.csv, returns None and writes nothing.
+
+    Title: "Wait-event breakdown — clean phase".
+    """
+    clean_phases = [p for p in phases if p.type is PhaseType.CLEAN]
+    if not clean_phases:
+        return None
+    clean_phase = clean_phases[0]
+
+    # For each system, build (event_type -> count) summed across event names
+    # in the clean phase, plus the total_active denominator.
+    by_system: dict[str, tuple[dict[str, int], int]] = {}
+    for system in systems:
+        per_type: dict[str, int] = {}
+        total_active = 0
+        for r in rows:
+            if (
+                r["system"] != system
+                or r["phase_label"] != clean_phase.label
+                or r.get("subject_kind") != "wait_event"
+            ):
+                continue
+            try:
+                value = int(float(r["value"]))
+            except (TypeError, ValueError):
+                continue
+            if r["metric"] == "total_active_samples":
+                total_active = max(total_active, value)
+                continue
+            if r["metric"] != "wait_event_count":
+                continue
+            subject = r["subject"]
+            event_type = subject.split(":", 1)[0] if ":" in subject else subject
+            per_type[event_type] = per_type.get(event_type, 0) + value
+        if per_type or total_active:
+            by_system[system] = (per_type, total_active)
+    if not by_system:
+        return None
+
+    # Pick top-N event types ranked by total count across all systems so
+    # the colour assignment is stable system-to-system.
+    global_totals: dict[str, int] = {}
+    for per_type, _ in by_system.values():
+        for event_type, count in per_type.items():
+            global_totals[event_type] = global_totals.get(event_type, 0) + count
+    ordered_types = [
+        t for t, _ in sorted(global_totals.items(), key=lambda kv: kv[1], reverse=True)
+    ]
+    top_types = ordered_types[:top_n]
+    other_present = len(ordered_types) > top_n
+
+    type_color = {
+        event_type: _PALETTE[i % len(_PALETTE)]
+        for i, event_type in enumerate(top_types)
+    }
+    if other_present:
+        type_color["Other"] = "#BAB0AC"
+
+    meta = system_meta or {}
+    bar_systems = [s for s in systems if s in by_system]
+    labels = [meta.get(s, (s, s))[1] for s in bar_systems]
+
+    # Build stacked fractions. Denominator is total_active when it's
+    # available (the harness always emits it), else the sum of bucket
+    # counts (covers the test path).
+    fractions: dict[str, list[float]] = {t: [] for t in top_types}
+    if other_present:
+        fractions["Other"] = []
+    for system in bar_systems:
+        per_type, total_active = by_system[system]
+        denom = total_active if total_active > 0 else sum(per_type.values()) or 1
+        used_in_top = 0
+        for event_type in top_types:
+            count = per_type.get(event_type, 0)
+            fractions[event_type].append(count / denom)
+            used_in_top += count
+        if other_present:
+            other_count = sum(per_type.values()) - used_in_top
+            fractions["Other"].append(max(0.0, other_count / denom))
+
+    fig, ax = plt.subplots(figsize=(max(6.0, 1.4 * len(bar_systems) + 3.5), 5.0))
+    x = np.arange(len(bar_systems))
+    bottom = np.zeros(len(bar_systems))
+    for event_type in list(top_types) + (["Other"] if other_present else []):
+        values = np.asarray(fractions[event_type])
+        ax.bar(
+            x,
+            values,
+            bottom=bottom,
+            color=type_color[event_type],
+            label=event_type,
+            edgecolor="white",
+            linewidth=0.5,
+        )
+        bottom = bottom + values
+
+    ax.set_xticks(x)
+    ax.set_xticklabels(labels, rotation=20, ha="right")
+    ax.set_ylabel("fraction of active-backend samples")
+    ax.set_ylim(0, 1.0)
+    ax.set_title(
+        f"Wait-event breakdown — clean phase ({clean_phase.label})",
+        pad=14,
+    )
+    ax.spines["top"].set_visible(False)
+    ax.spines["right"].set_visible(False)
+    ax.grid(True, axis="y", linestyle=":", color="#999", alpha=0.4)
+    ax.legend(
+        loc="center left",
+        bbox_to_anchor=(1.01, 0.5),
+        fontsize=9,
+        frameon=False,
+    )
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    fig.tight_layout(rect=[0, 0, 0.85, 1.0])
+    png = out_dir / "wait_events_clean.png"
+    svg = out_dir / "wait_events_clean.svg"
+    fig.savefig(png, dpi=300)
+    fig.savefig(svg)
+    plt.close(fig)
+    return png
+
+
 def render_faceted_dead_tuples(
     rows: list[dict],
     *,
@@ -606,4 +745,13 @@ def render_all(
         system_meta=system_meta,
     )
     out.append(out_dir / "dead_tuples_faceted.png")
+    wait_png = render_wait_events_clean_phase(
+        rows,
+        systems=systems,
+        phases=phases,
+        out_dir=out_dir,
+        system_meta=system_meta,
+    )
+    if wait_png is not None:
+        out.append(wait_png)
     return out

--- a/bench_harness/report.py
+++ b/bench_harness/report.py
@@ -77,6 +77,11 @@ PLOT_ORDER = [
     "dead_tuples",
     "dead_tuples_faceted",
     "table_size",
+    # Wait-event histogram per system (clean phase). Only rendered if any
+    # wait-event rows landed in raw.csv; the report's existence-check on
+    # the SVG file means this naturally degrades when --no-wait-events
+    # was set.
+    "wait_events_clean",
 ]
 
 

--- a/bench_harness/wait_events.py
+++ b/bench_harness/wait_events.py
@@ -1,0 +1,293 @@
+"""Wait-event sampling — pg_ash-style Active Session History, harness-side.
+
+Polls ``pg_stat_activity`` once per second from a dedicated PG connection and
+aggregates non-idle rows into a ``Counter`` keyed by
+``(phase_label, wait_event_type, wait_event)``. The result is a
+postgres-side breakdown of why each system is bottlenecked: lock contention
+vs IO waits vs CPU vs network. Same data shape pg_ash produces, minus the
+partition-rotation storage layer (which the harness doesn't need — it
+publishes counts to ``raw.csv`` and ``summary.json`` directly).
+
+Design notes
+------------
+- ``pg_stat_activity`` is a public catalog view. No SECURITY DEFINER, no
+  superuser. Standard ``postgres:17.2-alpine`` image stays.
+- One short SELECT per tick; each sample is well under a millisecond. At
+  the default 1 s cadence the overhead is negligible (< 0.1% of one core).
+- The sampler's own backend is filtered out via ``pg_backend_pid()`` so
+  we don't pollute counts with our own polling activity.
+- Phase labels come from the orchestrator's ``PhaseTracker`` so samples
+  are attributed to the phase active *when the sample was taken*, not the
+  phase active when the snapshot is emitted.
+- ``snapshot()`` returns a list of ``WaitEventCount`` rows for a single
+  phase — the orchestrator calls this on each phase boundary, the same
+  pattern the metrics daemon uses for its pgstattuple snapshot. Samples
+  for the *current* phase are preserved; only the phase being snapshot
+  is drained from the in-memory counter.
+"""
+
+from __future__ import annotations
+
+import sys
+import threading
+import time
+from collections import Counter
+from dataclasses import dataclass
+from typing import Callable, Iterable
+
+import psycopg
+
+
+# Public so tests can construct the same shape pg_stat_activity returns
+# without going through psycopg.
+@dataclass(frozen=True)
+class ActivityRow:
+    """One row from ``pg_stat_activity`` as the sampler consumes it.
+
+    Mirroring the column subset we actually use means tests can build a
+    fake snapshot without depending on a live PG instance. ``state`` is
+    intentionally typed as ``str | None`` because PG returns NULL for
+    backends that haven't started a transaction yet.
+    """
+
+    pid: int
+    state: str | None
+    wait_event_type: str | None
+    wait_event: str | None
+
+
+@dataclass(frozen=True)
+class WaitEventCount:
+    """One emitted row: counts of (event_type, event) for a single phase."""
+
+    phase_label: str
+    phase_type: str
+    wait_event_type: str
+    wait_event: str
+    count: int
+
+
+# The query we run every tick. Filters:
+# - state != 'idle'    → ignore idle pooled connections (otherwise they swamp
+#                        the counts with "Client:ClientRead" forever)
+# - pid <> pg_backend_pid() → exclude the sampler itself
+#
+# We keep ``query`` out of the SELECT list. It would help debugging but it
+# also makes the result set grow without bound (one entry per distinct query
+# text), and pg_stat_activity.query is truncated to ``track_activity_query_size``
+# anyway. The wait-event histogram is what we need — query attribution would
+# be a follow-up.
+_PG_STAT_ACTIVITY_SQL = """
+SELECT
+    pid,
+    state,
+    wait_event_type,
+    wait_event
+FROM pg_stat_activity
+WHERE pid <> pg_backend_pid()
+  AND state IS NOT NULL
+  AND state <> 'idle'
+"""
+
+
+def aggregate_rows(
+    rows: Iterable[ActivityRow],
+) -> Counter[tuple[str, str]]:
+    """Bucket a single tick of ``pg_stat_activity`` rows.
+
+    Returns a ``Counter`` keyed by ``(wait_event_type, wait_event)``. NULLs
+    in either column (a backend that's actively running CPU rather than
+    waiting) are bucketed under the synthetic key ``("CPU", "CPU")`` —
+    pg_ash uses the same convention. This keeps the histogram a complete
+    accounting of active backend time.
+
+    Pure function; the live sampler thread calls this with rows it just
+    fetched, and the unit test calls it with a hand-built list.
+    """
+    counter: Counter[tuple[str, str]] = Counter()
+    for row in rows:
+        # state filter is enforced server-side via the WHERE clause, but
+        # we re-check defensively because callers (tests) might hand-feed
+        # mixed rows and we don't want stray idle rows to leak in.
+        if row.state is None or row.state == "idle":
+            continue
+        event_type = row.wait_event_type
+        event = row.wait_event
+        if event_type is None and event is None:
+            # Backend is on CPU — neither waiting on a lock nor on IO.
+            counter[("CPU", "CPU")] += 1
+        else:
+            counter[(event_type or "Unknown", event or "Unknown")] += 1
+    return counter
+
+
+class WaitEventSampler:
+    """Background thread that samples ``pg_stat_activity`` periodically.
+
+    The sampler keeps two layers of state:
+
+    - ``_per_phase``: ``dict[phase_label -> Counter[(event_type, event)]]``.
+      Accumulates over the lifetime of the run. ``snapshot(phase_label)``
+      drains and returns this counter for one phase, leaving other phases
+      untouched.
+    - ``_total_active_samples``: scalar count of non-idle backends seen
+      across all ticks for one phase. Used as the denominator so callers
+      can compute "lock contention was 18% of active backend time".
+
+    Lifecycle: ``start()`` spawns the thread, ``stop()`` joins it. Safe
+    to call ``stop()`` multiple times. ``snapshot()`` is callable any
+    time; it acquires the same lock the sampler uses to update its
+    counters, so callers see consistent point-in-time totals.
+    """
+
+    def __init__(
+        self,
+        *,
+        database_url: str,
+        get_phase: Callable[[], tuple[str, str]],
+        sample_every_s: float = 1.0,
+    ) -> None:
+        self.database_url = database_url
+        self.get_phase = get_phase
+        self.sample_every_s = sample_every_s
+
+        self._lock = threading.Lock()
+        self._per_phase: dict[str, Counter[tuple[str, str]]] = {}
+        self._phase_types: dict[str, str] = {}
+        # Total non-idle backend observations per phase (sum of per-tick
+        # active backend counts). The denominator for percentages.
+        self._total_active_samples: dict[str, int] = {}
+
+        self._stop_event = threading.Event()
+        self._thread: threading.Thread | None = None
+
+    # ── lifecycle ──────────────────────────────────────────────────────
+    def start(self) -> None:
+        if self._thread is not None:
+            return
+        self._stop_event.clear()
+        self._thread = threading.Thread(
+            target=self._run,
+            name="wait-event-sampler",
+            daemon=True,
+        )
+        self._thread.start()
+
+    def stop(self, timeout: float = 5.0) -> None:
+        self._stop_event.set()
+        thread = self._thread
+        if thread is not None:
+            thread.join(timeout=timeout)
+            self._thread = None
+
+    # ── data ingestion (worker thread) ─────────────────────────────────
+    def _run(self) -> None:
+        try:
+            conn = psycopg.connect(self.database_url, autocommit=True)
+        except psycopg.Error as exc:
+            print(
+                f"[wait-events] failed to connect to "
+                f"{self.database_url!r}: {exc}",
+                file=sys.stderr,
+            )
+            return
+        try:
+            self._poll_loop(conn)
+        finally:
+            try:
+                conn.close()
+            except Exception:
+                pass
+
+    def _poll_loop(self, conn: "psycopg.Connection") -> None:
+        while not self._stop_event.is_set():
+            tick_start = time.time()
+            try:
+                self._poll_once(conn)
+            except psycopg.Error as exc:
+                # Don't kill the sampler on a transient PG error — the
+                # bench can outlive a brief connection blip. Log once and
+                # keep going; a hard, persistent failure will keep raising
+                # and just produce empty counters, which is the right
+                # observable behaviour ("no wait-event data") rather than
+                # crashing the whole orchestrator.
+                print(f"[wait-events] poll error: {exc}", file=sys.stderr)
+            elapsed = time.time() - tick_start
+            remaining = self.sample_every_s - elapsed
+            if remaining > 0:
+                # Wake early on stop.
+                self._stop_event.wait(timeout=remaining)
+
+    def _poll_once(self, conn: "psycopg.Connection") -> None:
+        with conn.cursor() as cur:
+            cur.execute(_PG_STAT_ACTIVITY_SQL)
+            raw_rows = cur.fetchall()
+        rows = [
+            ActivityRow(
+                pid=row[0],
+                state=row[1],
+                wait_event_type=row[2],
+                wait_event=row[3],
+            )
+            for row in raw_rows
+        ]
+        counts = aggregate_rows(rows)
+        if not counts:
+            # No active backends this tick — still record the phase so we
+            # get a bucket entry, but with zero samples; otherwise a phase
+            # that runs fully idle would never appear in `_per_phase` and
+            # the orchestrator's snapshot() would silently emit nothing.
+            phase_label, phase_type = self.get_phase()
+            with self._lock:
+                self._per_phase.setdefault(phase_label, Counter())
+                self._phase_types.setdefault(phase_label, phase_type)
+                # Total stays at 0 for this tick — no sample increment.
+            return
+        phase_label, phase_type = self.get_phase()
+        with self._lock:
+            bucket = self._per_phase.setdefault(phase_label, Counter())
+            self._phase_types.setdefault(phase_label, phase_type)
+            bucket.update(counts)
+            self._total_active_samples[phase_label] = (
+                self._total_active_samples.get(phase_label, 0)
+                + sum(counts.values())
+            )
+
+    # ── data egress (orchestrator thread) ──────────────────────────────
+    def snapshot(self, phase_label: str) -> tuple[list[WaitEventCount], int]:
+        """Drain the accumulated counts for one phase.
+
+        Returns ``(rows, total_active_samples)`` where ``rows`` is one
+        ``WaitEventCount`` per distinct ``(event_type, event)`` pair seen
+        during the phase. The phase's counter is removed from the
+        sampler's state so a follow-up ``snapshot`` of the same label
+        wouldn't double-count (relevant if the orchestrator ever revisits
+        a label, though today's phase-list validator forbids duplicate
+        labels).
+        """
+        with self._lock:
+            counts = self._per_phase.pop(phase_label, Counter())
+            phase_type = self._phase_types.pop(phase_label, "")
+            total = self._total_active_samples.pop(phase_label, 0)
+        rows = [
+            WaitEventCount(
+                phase_label=phase_label,
+                phase_type=phase_type,
+                wait_event_type=event_type,
+                wait_event=event,
+                count=count,
+            )
+            for (event_type, event), count in counts.most_common()
+        ]
+        return rows, total
+
+    def peek(self, phase_label: str) -> tuple[Counter[tuple[str, str]], int]:
+        """Read-only view of one phase's accumulated counts.
+
+        Used by tests; the orchestrator always calls ``snapshot`` so it
+        can drain. Returns a copy so the caller can't mutate sampler state.
+        """
+        with self._lock:
+            counts = Counter(self._per_phase.get(phase_label, Counter()))
+            total = self._total_active_samples.get(phase_label, 0)
+        return counts, total

--- a/bench_harness/writers.py
+++ b/bench_harness/writers.py
@@ -287,6 +287,11 @@ def compute_summary(
         ):
             # Defer to the per-timestamp aggregator below; skip raw bucket.
             continue
+        if row.get("subject_kind") == "wait_event":
+            # Wait-event rows have their own dedicated aggregation pass
+            # (top-N histogram per phase) and don't fit the generic
+            # (median, peak, count) shape — skip them in the bucket pass.
+            continue
         instance_id = row.get("instance_id") or ""
         key = (
             row["system"],
@@ -447,6 +452,11 @@ def compute_summary(
                 phase_label=phase_label,
             )
             phase_block["replicas"] = replicas
+            wait = _wait_event_summary(
+                rows, system=system, phase_label=phase_label
+            )
+            if wait is not None:
+                phase_block["wait_events"] = wait
 
     return {
         "run_id": run_id,
@@ -571,6 +581,65 @@ def _phase_summed_values(
             continue
         per_elapsed[elapsed_s] = per_elapsed.get(elapsed_s, 0.0) + value
     return list(per_elapsed.values())
+
+
+def _wait_event_summary(
+    rows: list[dict],
+    *,
+    system: str,
+    phase_label: str,
+    top_n: int = 10,
+) -> dict | None:
+    """Compute the wait-event histogram block for one (system, phase).
+
+    Returns a dict ``{"top": [...], "total_active_samples": N}`` or
+    ``None`` if no wait-event rows exist for this slice. ``top`` is the
+    N most-frequent ``(event_type, event)`` pairs, ordered by count
+    descending. ``total_active_samples`` is the denominator emitted by
+    the harness (sum of non-idle backend observations across all ticks
+    in the phase) so callers can compute percentages.
+    """
+    histogram: dict[str, int] = {}
+    total_active = 0
+    seen_any = False
+    for row in rows:
+        if (
+            row["system"] != system
+            or row["phase_label"] != phase_label
+            or row.get("subject_kind") != "wait_event"
+        ):
+            continue
+        seen_any = True
+        try:
+            value = float(row["value"])
+        except (TypeError, ValueError):
+            continue
+        if row["metric"] == "total_active_samples":
+            # The harness emits one denominator row per phase boundary;
+            # take the latest (= largest) to be defensive against any
+            # repeated emissions, though today's path emits exactly once.
+            total_active = max(total_active, int(value))
+            continue
+        if row["metric"] != "wait_event_count":
+            continue
+        # Subject is "<event_type>:<event_name>"; we sum counts in case
+        # the orchestrator ever splits a phase across multiple snapshots
+        # for the same label. Today's path emits one snapshot per phase.
+        histogram[row["subject"]] = histogram.get(row["subject"], 0) + int(value)
+    if not seen_any:
+        return None
+    top = sorted(histogram.items(), key=lambda kv: kv[1], reverse=True)[:top_n]
+    return {
+        "top": [
+            {
+                "event_type": subject.split(":", 1)[0] if ":" in subject else subject,
+                "event": subject.split(":", 1)[1] if ":" in subject else "",
+                "count": count,
+            }
+            for subject, count in top
+        ],
+        "total_active_samples": total_active,
+    }
 
 
 def _autovacuum_count_delta(

--- a/docs/wait-events.md
+++ b/docs/wait-events.md
@@ -1,0 +1,117 @@
+# Wait-event sampling primer
+
+Throughput and latency tell you *that* a system is slower than another.
+Wait events tell you *why*: which postgres-side resource is the queue
+spending time on. Same idea as Oracle's Active Session History (ASH) and
+the [pg_ash](https://github.com/NikolayS/pg_ash) extension, implemented
+inside the harness so we don't have to swap the postgres image.
+
+## How it works
+
+The orchestrator opens a dedicated Postgres connection and polls
+`pg_stat_activity` once per second:
+
+```sql
+SELECT pid, state, wait_event_type, wait_event
+FROM pg_stat_activity
+WHERE pid <> pg_backend_pid()
+  AND state IS NOT NULL
+  AND state <> 'idle';
+```
+
+Each row is a backend that was *active* (running a query, in a
+transaction, or waiting on a resource) at sample time. We bucket the
+rows into a `Counter[(wait_event_type, wait_event)]` per phase. Phase
+boundaries drain the counter into `raw.csv`:
+
+- `subject_kind = wait_event`
+- `subject = "<event_type>:<event_name>"` (e.g. `Lock:tuple`,
+  `IO:DataFileRead`, `LWLock:WALWrite`, `CPU:CPU`)
+- `metric = wait_event_count`, `value = sample count`
+- A companion row with `metric = total_active_samples` carries the
+  denominator so callers can compute percentages without re-summing.
+
+`pg_stat_activity` is a public catalog view. No `SECURITY DEFINER`,
+no superuser, no extension install — runs against the standard
+`postgres:17.2-alpine` image.
+
+## Reading the histogram
+
+`wait_event_type` is the coarse bucket. The ones you'll see most often
+in a job-queue workload:
+
+| Type        | What it means                                                                 |
+| ----------- | ----------------------------------------------------------------------------- |
+| `CPU`       | Synthetic bucket the harness uses for backends with no current wait. On-CPU. |
+| `Lock`      | Heavyweight lock contention (row, tuple, transaction, advisory).             |
+| `LWLock`    | Lightweight lock contention (buffers, WAL, locks themselves).                |
+| `IO`        | Disk reads / writes / fsync.                                                 |
+| `Client`    | Waiting on the client (`ClientRead` after a query returns, idle-in-tx).      |
+| `IPC`       | Inter-backend coordination (parallel query, replication).                    |
+| `BufferPin` | Concurrent reader holding a buffer pin.                                      |
+| `Activity`  | Background workers waiting for work (autovacuum launcher, archiver, etc.).   |
+
+`wait_event` is the fine-grained subevent — exact docs at
+<https://www.postgresql.org/docs/current/monitoring-stats.html#WAIT-EVENT-TABLE>.
+
+A few specific events to pattern-match against the job-queue systems we
+benchmark:
+
+- `Lock:tuple` — two workers are claiming the same row. Classic
+  signature of a system that doesn't use `SKIP LOCKED` (or uses it
+  with overlapping candidate sets).
+- `Lock:transactionid` — workers waiting on each other's
+  transaction commit. Often appears with `Lock:tuple`; the second
+  worker has acquired the row lock but still has to wait for the
+  first transaction to clear.
+- `LWLock:WALWrite`, `LWLock:WALInsert` — write amplification or
+  fsync pressure from each job's commit. Adapters that batch
+  completions usually have a much lower share here.
+- `IO:DataFileRead` — buffer cache thrashing. If this is high during
+  the clean phase, the working set has spilled out of
+  `shared_buffers`.
+- `Client:ClientRead` after filtering — should be near zero in our
+  setup (we filter `state != 'idle'`); seeing it means a backend
+  is in the middle of a query but blocked on the client side.
+- `CPU:CPU` (synthetic) — the backend was running, not waiting.
+  A high share here is *good* — it means the system is bottlenecked
+  on its own work, not on PG resources.
+
+## Reading the bar chart
+
+The `wait_events_clean` plot in `index.html` shows one bar per system,
+each segment being one wait-event type as a fraction of total active
+samples during the clean phase. Quick interpretation guide:
+
+- Dominantly **CPU** → adapter is bottlenecked in user-space (Rust,
+  Elixir, Python overhead) or in producer→completion pipelining,
+  not in PG.
+- Dominantly **Lock / LWLock** → contention. Look at
+  `summary.json -> systems.<sys>.phases.clean.wait_events.top` for
+  the specific events.
+- Dominantly **IO** → working set doesn't fit in `shared_buffers`,
+  or autovacuum is reading dead tuples back in.
+- A mix → typical at moderate load. The interesting reading is how
+  the mix shifts between systems at the *same* offered load.
+
+## Limitations
+
+- 1 s sampling cadence misses sub-second contention bursts. Drop
+  `--wait-event-sample-every` to e.g. 0.25 if you suspect short-lived
+  spikes; the overhead is still negligible.
+- We don't capture `query` text. That would let us attribute waits
+  to specific queries (claim vs ack vs cleanup) but `pg_stat_activity`
+  truncates at `track_activity_query_size` and the cardinality
+  explodes the storage. Follow-up: see issue tagged
+  `wait-events-query-attribution`.
+- Single-PID samples — we don't track `xact_start`, so we can't
+  derive *durations*, only sample counts. Counts are a good enough
+  proxy at fixed cadence.
+
+## Disabling
+
+```
+uv run python long_horizon.py run --no-wait-events ...
+```
+
+Default cadence is 1 s; tune with `--wait-event-sample-every 0.5` etc.

--- a/tests/test_harness_smoke.py
+++ b/tests/test_harness_smoke.py
@@ -820,3 +820,225 @@ def test_start_worker_hook_without_pool_errors():
     runtime = PhaseRuntime(database_url="", phase=phase, state={})
     with pytest.raises(RuntimeError, match="start-worker requires state"):
         enter_start_worker(runtime)
+
+
+# ── Wait-event sampling ─────────────────────────────────────────────────
+
+
+from bench_harness.wait_events import (
+    ActivityRow,
+    WaitEventCount,
+    WaitEventSampler,
+    aggregate_rows,
+)
+
+
+def test_aggregate_rows_buckets_by_event_pair():
+    rows = [
+        ActivityRow(pid=1, state="active", wait_event_type="Lock", wait_event="tuple"),
+        ActivityRow(pid=2, state="active", wait_event_type="Lock", wait_event="tuple"),
+        ActivityRow(
+            pid=3, state="active", wait_event_type="IO", wait_event="DataFileRead"
+        ),
+        ActivityRow(
+            pid=4, state="active", wait_event_type="LWLock", wait_event="WALWrite"
+        ),
+    ]
+    counts = aggregate_rows(rows)
+    assert counts[("Lock", "tuple")] == 2
+    assert counts[("IO", "DataFileRead")] == 1
+    assert counts[("LWLock", "WALWrite")] == 1
+
+
+def test_aggregate_rows_treats_null_wait_as_cpu():
+    # Backend on CPU: state set, no wait_event. pg_ash convention is to
+    # bucket these as "CPU:CPU" so the histogram remains a complete
+    # accounting of active backend time.
+    rows = [
+        ActivityRow(pid=1, state="active", wait_event_type=None, wait_event=None),
+        ActivityRow(pid=2, state="active", wait_event_type=None, wait_event=None),
+    ]
+    counts = aggregate_rows(rows)
+    assert counts[("CPU", "CPU")] == 2
+
+
+def test_aggregate_rows_skips_idle_state_defensively():
+    # The server-side WHERE filters idle, but the helper double-checks.
+    rows = [
+        ActivityRow(pid=1, state="idle", wait_event_type=None, wait_event=None),
+        ActivityRow(pid=2, state=None, wait_event_type=None, wait_event=None),
+        ActivityRow(
+            pid=3, state="active", wait_event_type="Lock", wait_event="tuple"
+        ),
+    ]
+    counts = aggregate_rows(rows)
+    assert sum(counts.values()) == 1
+    assert counts[("Lock", "tuple")] == 1
+
+
+def test_aggregate_rows_unknown_buckets():
+    # If the server hands us an event_type but no event name (or vice
+    # versa), bucket under "Unknown" rather than crashing.
+    rows = [
+        ActivityRow(
+            pid=1, state="active", wait_event_type="LWLock", wait_event=None
+        ),
+    ]
+    counts = aggregate_rows(rows)
+    assert counts[("LWLock", "Unknown")] == 1
+
+
+def test_sampler_snapshot_drains_per_phase():
+    # We stub _poll_once with hand-built ActivityRow lists so the test
+    # never touches a real PG connection. The sampler's locking +
+    # accumulation logic still runs end-to-end.
+    sampler = WaitEventSampler(
+        database_url="postgresql://nowhere",  # never used in this test
+        get_phase=lambda: ("clean_1", "clean"),
+        sample_every_s=0.01,
+    )
+    # Drive the in-memory accumulators directly via the public-ish
+    # _poll_once_body shape: feed rows in, then snapshot.
+    sampler._per_phase.setdefault("clean_1", __import__("collections").Counter())
+    sampler._phase_types["clean_1"] = "clean"
+    counts = aggregate_rows(
+        [
+            ActivityRow(
+                pid=1, state="active", wait_event_type="Lock", wait_event="tuple"
+            ),
+            ActivityRow(
+                pid=2, state="active", wait_event_type="Lock", wait_event="tuple"
+            ),
+            ActivityRow(
+                pid=3, state="active", wait_event_type="CPU", wait_event="CPU"
+            ),
+        ]
+    )
+    sampler._per_phase["clean_1"].update(counts)
+    sampler._total_active_samples["clean_1"] = 3
+    rows, total = sampler.snapshot("clean_1")
+    assert total == 3
+    # most_common ordering: Lock:tuple (2) before CPU:CPU (1).
+    assert rows[0] == WaitEventCount(
+        phase_label="clean_1",
+        phase_type="clean",
+        wait_event_type="Lock",
+        wait_event="tuple",
+        count=2,
+    )
+    assert rows[1].count == 1
+    # Drained: a second snapshot returns nothing.
+    rows2, total2 = sampler.snapshot("clean_1")
+    assert rows2 == []
+    assert total2 == 0
+
+
+def test_sampler_isolates_phases():
+    # Two phases observed back-to-back must end up in distinct buckets;
+    # a snapshot of one must not drain the other.
+    sampler = WaitEventSampler(
+        database_url="postgresql://nowhere",
+        get_phase=lambda: ("warmup", "warmup"),
+        sample_every_s=0.01,
+    )
+    from collections import Counter as _Counter
+
+    sampler._per_phase["warmup"] = _Counter({("CPU", "CPU"): 5})
+    sampler._phase_types["warmup"] = "warmup"
+    sampler._total_active_samples["warmup"] = 5
+    sampler._per_phase["clean_1"] = _Counter({("Lock", "tuple"): 7})
+    sampler._phase_types["clean_1"] = "clean"
+    sampler._total_active_samples["clean_1"] = 7
+    rows, total = sampler.snapshot("warmup")
+    assert total == 5
+    assert rows[0].wait_event_type == "CPU"
+    # Clean phase still intact.
+    rows, total = sampler.snapshot("clean_1")
+    assert total == 7
+    assert rows[0].wait_event == "tuple"
+
+
+def test_summary_includes_wait_event_block(tmp_path: Path):
+    # Cook up a raw.csv with both adapter rows and harness wait-event
+    # rows, then run compute_summary and confirm the wait_events block
+    # surfaces under the right phase. Keeps the integration test honest
+    # without booting Postgres.
+    import csv as _csv
+
+    raw_path = tmp_path / "raw.csv"
+    with raw_path.open("w", newline="") as fh:
+        writer = _csv.writer(fh)
+        writer.writerow(RAW_CSV_HEADER)
+        # One adapter sample so the system has presence.
+        writer.writerow([
+            "test", "awa", "0", "10.0", "2026-05-01T00:00:00Z",
+            "clean_1", "clean", "adapter", "", "completion_rate", "100.0", "30.0",
+        ])
+        # Wait-event histogram for the same phase.
+        writer.writerow([
+            "test", "awa", "0", "60.0", "2026-05-01T00:01:00Z",
+            "clean_1", "clean", "wait_event", "Lock:tuple",
+            "wait_event_count", "12.0", "60.0",
+        ])
+        writer.writerow([
+            "test", "awa", "0", "60.0", "2026-05-01T00:01:00Z",
+            "clean_1", "clean", "wait_event", "CPU:CPU",
+            "wait_event_count", "30.0", "60.0",
+        ])
+        writer.writerow([
+            "test", "awa", "0", "60.0", "2026-05-01T00:01:00Z",
+            "clean_1", "clean", "wait_event", "__total__",
+            "total_active_samples", "42.0", "60.0",
+        ])
+    phases = [parse_phase_spec("clean_1=clean:60s")]
+    summary = compute_summary(
+        raw_path, run_id="test", scenario=None, phases=phases
+    )
+    block = summary["systems"]["awa"]["phases"]["clean_1"]
+    assert "wait_events" in block
+    we = block["wait_events"]
+    assert we["total_active_samples"] == 42
+    # Top is sorted by count desc; CPU:CPU (30) > Lock:tuple (12).
+    assert we["top"][0]["event_type"] == "CPU"
+    assert we["top"][0]["count"] == 30
+    assert we["top"][1] == {
+        "event_type": "Lock", "event": "tuple", "count": 12,
+    }
+
+
+def test_cliconfig_wait_event_defaults():
+    # Defaults: ON, 1 s cadence.
+    config = CliConfig(**_config_kwargs())
+    assert config.wait_events is True
+    assert config.wait_event_sample_every == 1.0
+
+
+def test_cliconfig_wait_event_disable():
+    config = CliConfig(**_config_kwargs(wait_events=False))
+    assert config.wait_events is False
+
+
+def test_cliconfig_wait_event_rejects_non_positive_cadence():
+    with pytest.raises(ValidationError):
+        CliConfig(**_config_kwargs(wait_event_sample_every=0.0))
+
+
+def test_argparse_wait_event_flags():
+    from bench_harness.orchestrator import build_parser
+
+    p = build_parser()
+    ns = p.parse_args(["run", "--scenario", "idle_in_tx_saturation"])
+    assert ns.wait_events is True
+    assert ns.wait_event_sample_every == 1.0
+    ns = p.parse_args(
+        [
+            "run",
+            "--scenario",
+            "idle_in_tx_saturation",
+            "--no-wait-events",
+            "--wait-event-sample-every",
+            "0.5",
+        ]
+    )
+    assert ns.wait_events is False
+    assert ns.wait_event_sample_every == 0.5


### PR DESCRIPTION
## Summary

Adds harness-side wait-event sampling so cross-system runs surface the
**postgres-side reason** a system is bottlenecked, not just whether it
is. Same data shape [pg_ash](https://github.com/NikolayS/pg_ash)
produces — implemented inside the harness so the standard
`postgres:17.2-alpine` image stays untouched.

Follow-up to: #9 (expose pg_ash extension as opt-in once the image story
is sorted).

## Design choice (A vs B vs C)

Went with **B (harness-side sampling)** as the brief recommended:

- **A — install pg_ash extension.** Needs `pg_cron`, which standard
  `postgres:17.2-alpine` doesn't ship. Would have to switch the image
  for everyone, which confounds throughput comparisons across past and
  future runs. **Out of scope here.** Tracked in #9.
- **B — harness-side sampling.** New `WaitEventSampler` thread opens a
  dedicated PG connection and runs
  `SELECT pid, state, wait_event_type, wait_event FROM pg_stat_activity WHERE pid <> pg_backend_pid() AND state IS NOT NULL AND state <> 'idle'`
  every 1 s. Aggregates rows into `Counter[(event_type, event)]` per
  phase. Same result-shape pg_ash records, minus the partition-rotation
  storage layer (the harness doesn't need it — it just publishes counts
  to `raw.csv` directly). **This PR.**
- **C — hybrid.** Default to B. Leave structure for A behind a flag.
  This PR implements B; #9 carries A as the follow-up.

`pg_stat_activity` is a public catalog view: no `SECURITY DEFINER`,
no superuser, no extension install. Sampler filters out its own
backend via `pg_backend_pid()`.

## What it looks like

### CLI

ON by default. Opt out with `--no-wait-events`; tune with
`--wait-event-sample-every <seconds>`:

```
uv run python long_horizon.py run --systems awa,oban --replicas 1 \
  --worker-count 8 --producer-rate 200 \
  --phase warmup=warmup:15s --phase clean=clean:45s
  # default: 1 s sampling, on
```

### `raw.csv`

New `subject_kind=wait_event`, `metric=wait_event_count`,
`subject="<event_type>:<event_name>"` (e.g. `Lock:tuple`,
`IO:DataFileRead`, `LWLock:WALWriteLock`). One companion row per
phase with `metric=total_active_samples` carries the denominator.

```
custom-...,awa,0,60.845,...,clean,clean,wait_event,LWLock:WALWriteLock,wait_event_count,59.0,45.0
custom-...,awa,0,60.845,...,clean,clean,wait_event,IO:WalSync,wait_event_count,26.0,45.0
custom-...,awa,0,60.845,...,clean,clean,wait_event,CPU:CPU,wait_event_count,5.0,45.0
custom-...,awa,0,60.845,...,clean,clean,wait_event,Client:ClientRead,wait_event_count,5.0,45.0
custom-...,awa,0,60.845,...,clean,clean,wait_event,__total__,total_active_samples,95.0,45.0
```

### `summary.json`

Per system per phase, top-10 events plus the denominator under
`systems.<sys>.phases.<phase>.wait_events`:

```json
{
  "top": [
    {"event_type": "LWLock", "event": "WALWriteLock", "count": 59},
    {"event_type": "IO",     "event": "WalSync",      "count": 26},
    {"event_type": "CPU",    "event": "CPU",          "count": 5},
    {"event_type": "Client", "event": "ClientRead",   "count": 5}
  ],
  "total_active_samples": 95
}
```

### `index.html`

New stacked-bar plot per system: top-5 wait-event types as a fraction
of total active-backend samples during the (first) clean phase. One
bar per system, segments coloured by event type from the standard
palette. Title: "Wait-event breakdown — clean phase".

## Smoke run excerpt

60 s smoke, awa, single replica, 200 jobs/s, 8 workers,
warmup=15s clean=45s. The clean-phase histogram for awa surfaces
the expected commit-side bottleneck:

| Event              | Count | % of active |
| ------------------ | ----- | ----------- |
| LWLock:WALWriteLock | 59   | 62%         |
| IO:WalSync          | 26   | 27%         |
| CPU:CPU             | 5    | 5%          |
| Client:ClientRead   | 5    | 5%          |
| **total active**    | 95   | —           |

Reads as: at 200 jobs/s with synchronous_commit on, awa is dominantly
bottlenecked on WAL flushing. Exactly the kind of insight the throughput
plot couldn't have shown on its own. Spot-checked in
`results/custom-20260501T025002Z-dc2a57/`:
`raw.csv` had 9 wait_event rows, `summary.json` carries the block,
`plots/wait_events_clean.{png,svg}` rendered, and `index.html`
references it.

## What's in the PR

- `bench_harness/wait_events.py` — the sampler. `aggregate_rows` is a
  pure helper (unit-tested) and the `WaitEventSampler` thread wraps it
  with phase-tagged buckets and locked snapshot/peek.
- `bench_harness/orchestrator.py` — start sampler with the metrics
  daemon; emit `Sample` rows on each phase boundary; stop on shutdown.
- `bench_harness/config.py` — `wait_events: bool` and
  `wait_event_sample_every: float` validation.
- `bench_harness/writers.py` — `_wait_event_summary` produces the
  per-phase top-N + denominator block, plumbed into `compute_summary`.
- `bench_harness/plots.py` — `render_wait_events_clean_phase` stacked
  bar; called from `render_all`. Falls back gracefully (returns None,
  emits nothing) if no clean phase or no wait-event rows.
- `bench_harness/report.py` — adds `wait_events_clean` to `PLOT_ORDER`
  so `index.html` picks it up automatically when present.
- `docs/wait-events.md` — primer (event types you'll see, how to read
  the bar chart, limitations, follow-up).
- `README.md` — short paragraph linking to the primer.
- `tests/test_harness_smoke.py` — 11 new unit tests covering
  `aggregate_rows` (incl. CPU/Unknown/idle defensive cases),
  `WaitEventSampler.snapshot` per-phase isolation, summary.json
  integration via a hand-built `raw.csv`, CliConfig defaults +
  rejection of bad cadence, argparse `--no-wait-events` /
  `--wait-event-sample-every` plumbing.

## Constraints respected

- **Public API only.** No `SECURITY DEFINER`, no superuser, no
  extension install. Standard `pg_stat_activity` selects.
- **No image change.** `postgres:17.2-alpine` stays. pg_ash extension
  itself is out of scope (#9).
- **JSON-on-stdout sample contract intact.** Adapter rows still flow
  through `parse_adapter_record` exactly as before. Wait-event rows
  enter from a different writer path; the new `subject_kind=wait_event`
  is the discriminator so analyses can include or exclude them
  cleanly.
- **Sample cadence:** 1 s default, configurable via
  `--wait-event-sample-every`. Default ON; opt out with
  `--no-wait-events`.
- **Performance:** one short SELECT against `pg_stat_activity` per
  tick. Negligible overhead. Confirmed by clean smoke run completing
  in expected wall-clock.

## Test plan

- [x] `uv run pytest tests/ -q` — 85 passed (74 → 85, +11 new tests).
- [x] 60 s smoke against `awa`: `raw.csv` has `wait_event_count` rows;
      `summary.json` has the wait-events block; `index.html` references
      `plots/wait_events_clean.svg`; the SVG file exists.
- [ ] Reviewer: run the full `event_delivery_matrix` scenario across
      all 7 systems and skim the bar chart for the expected
      cross-system contrast (e.g. row-locking vs SKIP LOCKED vs
      partitioned designs).
- [ ] Reviewer: confirm the harness-side sampler doesn't perceptibly
      shift throughput numbers vs. a `--no-wait-events` baseline run
      on the same hardware.