### PR TITLE
feat: fold chaos scenarios into long_horizon phase types (#12 partial, #13)

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,23 +81,37 @@ Numbers are reproducible — re-run on your hardware and check.
 
 ## Chaos / correctness
 
-Partial. The long_horizon harness supports `kill-worker` /
-`start-worker` phase types and emits sample-stream metrics through
-chaos events. Published so far:
+Chaos scenarios run inside the same `long_horizon.py` harness as
+every other workload, as named compositions of phase types. The
+sample-stream metrics, wait-event histograms, and per-phase
+aggregates the steady-state runs produce all carry over; in
+addition the harness derives `jobs_lost` (cumulative
+`enqueue_rate − completion_rate` across the chaos and recovery
+phases) and `chaos_recovery_time_s` (time from end of chaos until
+completion rate re-attains 90% of baseline median) and writes them
+into `summary.json` for the recovery phase. Published so far:
 
 - [awa under crash_recovery](results/2026-05-02-awa-crash-recovery/SUMMARY.md)
   — replica 0 SIGKILLed mid-run; throughput stays in the 400-480
   jobs/s band across all five phases (baseline / pressure / kill /
   restart / recovery), wait-event profile invariant.
 
-The legacy `chaos.py` runner covers more scenarios
-(`postgres_restart`, `repeated_kills`, `pg_backend_kill`,
-`leader_failover`, `pool_exhaustion`, `retry_storm`,
-`priority_starvation`) but hasn't been modernised for awa 0.6's
-queue-storage tables, and doesn't include pgque / pgboss / pgmq.
-The full cross-system chaos picture is tracked under
-[#12](https://github.com/hardbyte/postgresql-job-queue-benchmarking/issues/12)
-and the runner-architecture rework under
+Available chaos scenarios:
+
+| Scenario | What it exercises |
+|---|---|
+| `chaos_crash_recovery` | Kill replica 0, restart, recover. Pair with `--replicas >= 2`. |
+| `chaos_postgres_restart` | Stop and restart Postgres mid-run; verify reconnect + completion. |
+| `chaos_repeated_kills` | Periodic SIGKILL+restart of replica 0; cumulative no-loss. |
+| `chaos_pg_backend_kill` | `pg_terminate_backend` of the SUT's backends at fixed rate. |
+| `chaos_pool_exhaustion` | Hold N idle connections to verify SUT survives pool pressure. |
+
+The legacy `chaos.py` runner is deprecated and kept only as a
+reference for `leader_failover`, `retry_storm`, and
+`priority_starvation` — those are system-specific and not yet
+folded in. The full cross-system chaos picture is tracked under
+[#12](https://github.com/hardbyte/postgresql-job-queue-benchmarking/issues/12);
+the runner consolidation lands in
 [#13](https://github.com/hardbyte/postgresql-job-queue-benchmarking/issues/13).
 
 ## Adapters
@@ -170,6 +184,11 @@ to `long_horizon.py run`, or compose your own with `--phase
 | `soak` | Warmup + 6 hours clean. Used to detect slow drift that shorter runs miss. |
 | `crash_recovery` | Clean → SIGKILL replica 0 → restart → recovery. Pair with `--replicas >= 2` for a meaningful "fleet covers the kill" measurement; single-replica still works but the recovery phase just measures time-to-empty. |
 | `crash_recovery_under_load` | `crash_recovery` with a high-load phase before the kill, so the fleet is already under backlog pressure. Pair with `--replicas >= 2`. |
+| `chaos_crash_recovery` | Warmup → baseline → SIGKILL replica 0 → restart → recovery. Aggregates `jobs_lost` and `chaos_recovery_time_s` into `summary.json`. |
+| `chaos_postgres_restart` | Stop + start the Postgres container mid-run; SUT must reconnect and drain. |
+| `chaos_repeated_kills` | Periodic SIGKILL+restart of replica 0 across a sustained chaos phase. |
+| `chaos_pg_backend_kill` | Steady stream of `pg_terminate_backend` against the SUT's connections. |
+| `chaos_pool_exhaustion` | Hold 300 idle connections to pressure the SUT's pool sizing. |
 
 ### Phase types (compose your own)
 
@@ -183,23 +202,22 @@ to `long_horizon.py run`, or compose your own with `--phase
 | `recovery` | Producer load drops to baseline; the bench measures how the system catches up after a stress phase. |
 | `kill-worker(instance=N)` | SIGKILLs replica N and waits for the configured duration. Used inside `crash_recovery` scenarios. |
 | `start-worker(instance=N)` | Restarts a previously killed replica and watches for re-registration. |
+| `postgres-restart` | `docker compose stop postgres` for half the duration, then `start` for the rest. Drives the harness-managed compose lifecycle. |
+| `pg-backend-kill(rate=N)` | Opens an admin connection that runs `pg_terminate_backend(pid)` against the SUT's database `N` times per second. |
+| `pool-exhaustion(idle_conns=N)` | Holds `N` idle connections against the SUT's database for the duration; releases them on phase end. |
+| `repeated-kill(instance=I,period=Ns)` | Periodic SIGKILL + auto-restart of replica `I` every `period`. Composes `kill-worker` / `start-worker`. |
 
-### `chaos.py` scenarios
+### `chaos.py` (deprecated)
 
-`chaos.py` is the correctness-under-adversity comparison runner (separate
-from `long_horizon.py` because it issues SIGKILLs and Postgres restarts
-that are incompatible with throughput sampling).
-
-| Scenario | What it exercises |
-|---|---|
-| `crash_recovery` | SIGKILL the worker mid-flight; verify all enqueued jobs eventually complete after restart with no loss and no duplicates. |
-| `postgres_restart` | Stop and restart the Postgres container while jobs are in flight; verify reconnect + no loss. |
-| `repeated_kills` | SIGKILL the worker repeatedly during a sustained run; verify cumulative no-loss. |
-| `pg_backend_kill` | `pg_terminate_backend` the worker's session repeatedly; verify reconnect path. |
-| `leader_failover` | Force leader election by killing the current leader; verify maintenance work continues. |
-| `pool_exhaustion` | Saturate the worker's connection pool and verify it recovers without hanging. |
-| `retry_storm` | Drive a high concurrent retry rate; verify no duplicate completions. |
-| `priority_starvation` | Mix high- and low-priority work; verify low priority eventually runs (priority aging). |
+`chaos.py` was the standalone chaos comparison runner. Its
+scenarios have been folded into `long_horizon.py` as named phase
+compositions (see the `chaos_*` rows above and the `kill-worker`,
+`postgres-restart`, `pg-backend-kill`, `pool-exhaustion`, and
+`repeated-kill` phase types). The script is retained in the repo
+as a reference for `leader_failover`, `retry_storm`, and
+`priority_starvation` — those scenarios are system-specific and
+have not yet been migrated. New chaos measurements should go
+through `long_horizon.py run --scenario chaos_*`.
 
 ## Wait-event sampling
 

--- a/bench_harness/hooks.py
+++ b/bench_harness/hooks.py
@@ -226,3 +226,301 @@ def enter_start_worker(runtime: PhaseRuntime) -> None:
         )
     instance = runtime.phase.int_param("instance", default=0)
     pool.start_worker(instance)
+
+
+# ─── postgres-restart ────────────────────────────────────────────────────
+#
+# Take Postgres down for the first half of the phase duration, then bring
+# it back up for the remainder. Drives the compose `postgres_restart_fn`
+# the orchestrator stashed on runtime.state so the hook stays free of
+# compose / docker knowledge.
+
+
+def enter_postgres_restart(runtime: PhaseRuntime) -> None:
+    restart_fn = runtime.state.get("postgres_restart_fn")
+    if restart_fn is None:
+        raise RuntimeError(
+            "postgres-restart requires state['postgres_restart_fn']. "
+            "The orchestrator sets this in run_one_system; running a "
+            "postgres-restart phase outside that context is a misconfiguration."
+        )
+    duration_s = runtime.phase.duration_s
+    # Stop immediately on enter; the harness phase loop sleeps for the
+    # full duration after the enter hook returns. We schedule the
+    # restart on a background thread so half the phase is "down" and
+    # the second half is "back up + measuring recovery in-phase."
+    stop_event = threading.Event()
+    holder: dict[str, Any] = {"stop": stop_event, "error": None}
+
+    # Identify which compose helper to use — the orchestrator provides
+    # the compound restart_fn (stop + start). For the first-half-down
+    # behaviour we need the two halves separately. Pull the underlying
+    # callables off state if present; otherwise fall back to invoking
+    # restart_fn (which is a stop+start) at t=0 and accepting the
+    # phase being mostly "down then up at the very end" — this fallback
+    # path is only taken in tests that don't wire the helpers in.
+    stop_fn = runtime.state.get("postgres_stop_fn")
+    start_fn = runtime.state.get("postgres_start_fn")
+
+    def _run() -> None:
+        try:
+            half = max(1.0, duration_s / 2.0)
+            if stop_fn:
+                stop_fn()
+            else:
+                # No split helpers: do the whole stop+start now and
+                # treat the rest of the phase as recovery observation.
+                restart_fn()
+                return
+            # Wait for the first-half mark or an early-exit signal.
+            if stop_event.wait(timeout=half):
+                # Phase ended early; bring PG back up regardless.
+                pass
+            if start_fn:
+                start_fn()
+        except Exception as exc:  # surfaced by the exit hook
+            holder["error"] = exc
+
+    thread = threading.Thread(
+        target=_run, name="postgres-restart-driver", daemon=True
+    )
+    thread.start()
+    holder["thread"] = thread
+    runtime.state["postgres-restart"] = holder
+
+
+def exit_postgres_restart(runtime: PhaseRuntime) -> None:
+    holder = runtime.state.pop("postgres-restart", None)
+    if not holder:
+        return
+    holder["stop"].set()
+    thread: threading.Thread = holder["thread"]
+    # Generous join — start_postgres in the orchestrator can take ~30s
+    # on a cold image pull. We must not return from exit before PG is
+    # back up; the next phase's adapter samples would fail otherwise.
+    thread.join(timeout=120.0)
+    if holder.get("error"):
+        raise RuntimeError(
+            f"postgres-restart driver thread failed: {holder['error']}"
+        ) from holder["error"]
+
+
+# ─── pg-backend-kill ─────────────────────────────────────────────────────
+#
+# Open one sampler connection (admin DB) that runs `pg_terminate_backend`
+# against the system-under-test's backends every `1/rate` seconds.
+# Targets backends connected to the system's database (datname filter)
+# rather than relying on application_name, which adapters don't
+# uniformly set.
+
+
+def _pg_backend_kill_loop(
+    admin_url: str,
+    target_db: str,
+    rate: float,
+    stop: threading.Event,
+    holder: dict[str, Any],
+) -> None:
+    period = 1.0 / max(rate, 0.01)
+    sql = (
+        "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+        "WHERE datname = %s "
+        "AND pid <> pg_backend_pid() "
+        "AND state IN ('active', 'idle in transaction')"
+    )
+    try:
+        with psycopg.connect(admin_url, autocommit=True) as conn:
+            with conn.cursor() as cur:
+                while not stop.is_set():
+                    try:
+                        cur.execute(sql, (target_db,))
+                        cur.fetchall()
+                        holder["kills"] = holder.get("kills", 0) + (cur.rowcount or 0)
+                    except psycopg.Error:
+                        # PG might bounce mid-loop in combined chaos
+                        # scenarios; reconnect on the next tick.
+                        break
+                    if stop.wait(timeout=period):
+                        return
+    except psycopg.Error as exc:
+        holder["error"] = exc
+
+
+def enter_pg_backend_kill(runtime: PhaseRuntime) -> None:
+    admin_url = runtime.state.get("admin_database_url") or runtime.database_url
+    target_db = runtime.state.get("system_database_name")
+    if not target_db:
+        raise RuntimeError(
+            "pg-backend-kill requires state['system_database_name']."
+        )
+    rate = float(runtime.phase.param("rate", "2"))
+    stop = threading.Event()
+    holder: dict[str, Any] = {"stop": stop}
+    thread = threading.Thread(
+        target=_pg_backend_kill_loop,
+        args=(admin_url, str(target_db), rate, stop, holder),
+        name="pg-backend-kill",
+        daemon=True,
+    )
+    thread.start()
+    holder["thread"] = thread
+    runtime.state["pg-backend-kill"] = holder
+
+
+def exit_pg_backend_kill(runtime: PhaseRuntime) -> None:
+    holder = runtime.state.pop("pg-backend-kill", None)
+    if not holder:
+        return
+    holder["stop"].set()
+    holder["thread"].join(timeout=5.0)
+
+
+# ─── pool-exhaustion ─────────────────────────────────────────────────────
+#
+# Open N idle connections held against the system-under-test's database
+# for the phase duration. Verifies that the SUT survives connection
+# pressure (and that its own pool sizing leaves headroom).
+#
+# Connections are opened best-effort: if PG's `max_connections` is below
+# the requested count we open as many as we can and log the shortfall
+# rather than aborting — the chaos point is "what happens under
+# pressure," not "fail the run if PG can't fit our request."
+
+
+def _pool_exhaustion_holder(
+    database_url: str,
+    n: int,
+    ready: threading.Event,
+    stop: threading.Event,
+    holder: dict[str, Any],
+) -> None:
+    conns: list[psycopg.Connection] = []
+    try:
+        for _ in range(n):
+            try:
+                conn = psycopg.connect(database_url, autocommit=True)
+                conns.append(conn)
+            except psycopg.Error as exc:
+                holder.setdefault("errors", []).append(str(exc))
+                break
+        holder["opened"] = len(conns)
+        ready.set()
+        stop.wait()
+    finally:
+        for c in conns:
+            try:
+                c.close()
+            except Exception:
+                pass
+
+
+def enter_pool_exhaustion(runtime: PhaseRuntime) -> None:
+    n = runtime.phase.int_param("idle_conns", default=300)
+    db_url = runtime.state.get("system_database_url") or runtime.database_url
+    stop = threading.Event()
+    ready = threading.Event()
+    holder: dict[str, Any] = {"stop": stop, "ready": ready}
+    thread = threading.Thread(
+        target=_pool_exhaustion_holder,
+        args=(db_url, n, ready, stop, holder),
+        name="pool-exhaustion",
+        daemon=True,
+    )
+    thread.start()
+    holder["thread"] = thread
+    runtime.state["pool-exhaustion"] = holder
+    # Don't block the phase loop on full pool fill; the holder thread
+    # races to open connections in the background. A short ready-wait
+    # ensures we've at least started before the phase clock advances.
+    ready.wait(timeout=10.0)
+
+
+def exit_pool_exhaustion(runtime: PhaseRuntime) -> None:
+    holder = runtime.state.pop("pool-exhaustion", None)
+    if not holder:
+        return
+    holder["stop"].set()
+    holder["thread"].join(timeout=10.0)
+
+
+# ─── repeated-kill ───────────────────────────────────────────────────────
+#
+# Periodic SIGKILL + auto-restart of replica I every `period` seconds
+# throughout phase duration. Composes the existing replica pool kill /
+# start operations so it stays consistent with `crash_recovery`.
+
+
+def _repeated_kill_loop(
+    pool: Any,
+    instance: int,
+    period_s: float,
+    stop: threading.Event,
+    holder: dict[str, Any],
+) -> None:
+    try:
+        while not stop.is_set():
+            if stop.wait(timeout=period_s):
+                return
+            try:
+                pool.kill_worker(instance)
+            except Exception as exc:
+                holder.setdefault("errors", []).append(f"kill: {exc}")
+                continue
+            # Brief pause to let the kill register before restarting.
+            if stop.wait(timeout=1.0):
+                return
+            try:
+                pool.start_worker(instance)
+                holder["cycles"] = holder.get("cycles", 0) + 1
+            except Exception as exc:
+                holder.setdefault("errors", []).append(f"start: {exc}")
+    except Exception as exc:
+        holder["error"] = exc
+
+
+def enter_repeated_kill(runtime: PhaseRuntime) -> None:
+    pool = runtime.state.get("replica_pool")
+    if pool is None:
+        raise RuntimeError(
+            "repeated-kill requires state['replica_pool']."
+        )
+    instance = runtime.phase.int_param("instance", default=0)
+    period_raw = runtime.phase.param("period", "20s")
+    # Reuse the same duration parser the DSL uses so `period=20s` /
+    # `period=1m` / `period=45` all do the right thing.
+    from .phases import parse_duration
+
+    period_s = float(parse_duration(period_raw))
+    stop = threading.Event()
+    holder: dict[str, Any] = {"stop": stop, "instance": instance}
+    thread = threading.Thread(
+        target=_repeated_kill_loop,
+        args=(pool, instance, period_s, stop, holder),
+        name="repeated-kill",
+        daemon=True,
+    )
+    thread.start()
+    holder["thread"] = thread
+    runtime.state["repeated-kill"] = holder
+
+
+def exit_repeated_kill(runtime: PhaseRuntime) -> None:
+    holder = runtime.state.pop("repeated-kill", None)
+    if not holder:
+        return
+    holder["stop"].set()
+    holder["thread"].join(timeout=10.0)
+    # Ensure the targeted replica is RUNNING when we leave the phase —
+    # otherwise the recovery phase would show artificial throughput
+    # depression caused by a still-dead replica, not by the chaos.
+    pool = runtime.state.get("replica_pool")
+    if pool is None:
+        return
+    # Best-effort: pool.start_worker raises if it's already running.
+    instance = holder.get("instance")
+    if instance is None:
+        return
+    try:
+        pool.start_worker(instance)
+    except Exception:
+        pass

--- a/bench_harness/orchestrator.py
+++ b/bench_harness/orchestrator.py
@@ -155,6 +155,69 @@ def start_postgres(pg_image: str) -> None:
     )
 
 
+def _compose_stop_postgres(pg_image: str) -> None:
+    """Stop (but don't remove) the postgres container — used by the
+    `postgres-restart` chaos phase to take PG down mid-run without
+    blowing away the volume the system-under-test is talking to."""
+    _run_cmd(
+        ["docker", "compose", "stop", "postgres"],
+        cwd=SCRIPT_DIR,
+        env=_compose_env(pg_image),
+        check=False,
+    )
+
+
+def _compose_start_postgres(pg_image: str) -> None:
+    """Start the existing postgres container and wait for readiness.
+
+    Re-uses the same readiness probe as ``start_postgres`` so callers
+    that bring PG back up after a chaos `stop` get the same guarantees
+    (pg_isready + a real SELECT 1 round-trip).
+    """
+    _run_cmd(
+        ["docker", "compose", "start", "postgres"],
+        cwd=SCRIPT_DIR,
+        env=_compose_env(pg_image),
+    )
+    for _ in range(60):
+        r = subprocess.run(
+            [
+                "docker", "compose", "exec", "-T", "postgres",
+                "pg_isready", "-U", "bench",
+            ],
+            cwd=str(SCRIPT_DIR),
+            env={**os.environ, **_compose_env(pg_image)},
+            capture_output=True,
+        )
+        if r.returncode == 0:
+            break
+        time.sleep(1)
+    else:
+        raise RuntimeError("Postgres did not become ready after restart")
+    last_error: Exception | None = None
+    for _ in range(30):
+        try:
+            with psycopg.connect(pg_url("postgres"), autocommit=True) as conn:
+                with conn.cursor() as cur:
+                    cur.execute("SELECT 1")
+                    cur.fetchone()
+            return
+        except psycopg.Error as exc:
+            last_error = exc
+            time.sleep(1)
+    raise RuntimeError(
+        f"Postgres started but never became query-ready: {last_error}"
+    )
+
+
+def _restart_postgres(pg_image: str) -> None:
+    """Stop + start the postgres container. Bound into runtime.state by
+    the orchestrator so the postgres-restart phase hook doesn't need to
+    know about compose at all."""
+    _compose_stop_postgres(pg_image)
+    _compose_start_postgres(pg_image)
+
+
 def stop_postgres(pg_image: str) -> None:
     if os.environ.get("KEEP_DB"):
         print("[harness] KEEP_DB set — leaving postgres running for inspection")
@@ -659,6 +722,16 @@ def run_one_system(
         # rolling-replace — landing in #174 step 4+) act on this.
         # Pre-existing phase hooks ignore it.
         "replica_pool": pool,
+        # Chaos phase types need to drive the compose lifecycle (postgres
+        # restart) and know where to wait afterwards. Stash a no-arg
+        # restart callback + URL probe instead of leaking compose
+        # internals into the hooks module.
+        "postgres_restart_fn": lambda: _restart_postgres(pg_image),
+        "postgres_stop_fn": lambda: _compose_stop_postgres(pg_image),
+        "postgres_start_fn": lambda: _compose_start_postgres(pg_image),
+        "admin_database_url": pg_url("postgres"),
+        "system_database_url": pg_url(manifest.db_name),
+        "system_database_name": manifest.db_name,
     }
     try:
         for phase in phases:

--- a/bench_harness/phases.py
+++ b/bench_harness/phases.py
@@ -24,6 +24,11 @@ class PhaseType(str, Enum):
     # Destructive / lifecycle phases. See UNIFIED_DRIVER_DESIGN.md §2.
     KILL_WORKER = "kill-worker"
     START_WORKER = "start-worker"
+    # Chaos phase types (folded in from chaos.py — see issue #13).
+    POSTGRES_RESTART = "postgres-restart"
+    PG_BACKEND_KILL = "pg-backend-kill"
+    POOL_EXHAUSTION = "pool-exhaustion"
+    REPEATED_KILL = "repeated-kill"
 
 
 # Matplotlib-compatible colour tints. Tuned for the dark "neutral gray" base
@@ -38,6 +43,11 @@ PHASE_TINTS: dict[PhaseType, tuple[str, float]] = {
     # Destructive: kill is scream-red, start is calm-green.
     PhaseType.KILL_WORKER:     ("#C04A4A", 0.35),
     PhaseType.START_WORKER:    ("#6CAF6C", 0.25),
+    # Chaos: shades of red/orange to flag stress phases visually.
+    PhaseType.POSTGRES_RESTART: ("#A03030", 0.40),
+    PhaseType.PG_BACKEND_KILL:  ("#D86A3A", 0.30),
+    PhaseType.POOL_EXHAUSTION:  ("#C8884A", 0.30),
+    PhaseType.REPEATED_KILL:    ("#B04040", 0.35),
 }
 
 # Whether samples in this phase type feed into summary.json (warmup excluded).
@@ -52,6 +62,10 @@ PHASE_INCLUDED_IN_SUMMARY: dict[PhaseType, bool] = {
     PhaseType.HIGH_LOAD:       True,
     PhaseType.KILL_WORKER:     True,
     PhaseType.START_WORKER:    True,
+    PhaseType.POSTGRES_RESTART: True,
+    PhaseType.PG_BACKEND_KILL:  True,
+    PhaseType.POOL_EXHAUSTION:  True,
+    PhaseType.REPEATED_KILL:    True,
 }
 
 
@@ -263,6 +277,42 @@ SCENARIOS: dict[str, list[str]] = {
         "restart=start-worker(instance=0):60s",
         "recovery_1=clean:120s",
     ],
+    # ── Chaos scenarios (folded in from chaos.py — see issue #13) ──────
+    # Each scenario follows the same warmup→baseline→stress→recovery
+    # shape, so the per-phase aggregator can diff enqueue/completion
+    # cumulatives across the stress + recovery span to surface
+    # jobs_lost / recovery_time in summary.json.
+    "chaos_crash_recovery": [
+        "warmup=warmup:30s",
+        "baseline=clean:60s",
+        "kill=kill-worker(instance=0):60s",
+        "restart=start-worker(instance=0):60s",
+        "recovery=clean:60s",
+    ],
+    "chaos_postgres_restart": [
+        "warmup=warmup:30s",
+        "baseline=clean:60s",
+        "restart=postgres-restart:60s",
+        "recovery=clean:60s",
+    ],
+    "chaos_repeated_kills": [
+        "warmup=warmup:30s",
+        "baseline=clean:60s",
+        "repeated=repeated-kill(instance=0,period=20s):120s",
+        "recovery=clean:60s",
+    ],
+    "chaos_pg_backend_kill": [
+        "warmup=warmup:30s",
+        "baseline=clean:60s",
+        "kills=pg-backend-kill(rate=2):60s",
+        "recovery=clean:60s",
+    ],
+    "chaos_pool_exhaustion": [
+        "warmup=warmup:30s",
+        "baseline=clean:60s",
+        "exhaustion=pool-exhaustion(idle_conns=300):60s",
+        "recovery=clean:60s",
+    ],
 }
 
 
@@ -371,6 +421,19 @@ def default_registry() -> HookRegistry:
                       enter=hooks.enter_kill_worker)
     registry.register(PhaseType.START_WORKER,
                       enter=hooks.enter_start_worker)
+    # Chaos phase types — folded in from chaos.py. See hooks.py.
+    registry.register(PhaseType.POSTGRES_RESTART,
+                      enter=hooks.enter_postgres_restart,
+                      exit=hooks.exit_postgres_restart)
+    registry.register(PhaseType.PG_BACKEND_KILL,
+                      enter=hooks.enter_pg_backend_kill,
+                      exit=hooks.exit_pg_backend_kill)
+    registry.register(PhaseType.POOL_EXHAUSTION,
+                      enter=hooks.enter_pool_exhaustion,
+                      exit=hooks.exit_pool_exhaustion)
+    registry.register(PhaseType.REPEATED_KILL,
+                      enter=hooks.enter_repeated_kill,
+                      exit=hooks.exit_repeated_kill)
     # warmup, clean, recovery — no extra runtime action; the adapter's
     # steady workload carries the load.
     return registry

--- a/bench_harness/writers.py
+++ b/bench_harness/writers.py
@@ -405,6 +405,61 @@ def compute_summary(
                 )
                 target.update(rec)
 
+    # Chaos aggregates: jobs_lost + chaos_recovery_time_s for every
+    # scenario that contains a destructive / chaos phase. Computed once,
+    # attached to the recovery phase block so the metric lives next to
+    # the data the operator actually reads ("how long did it take to come
+    # back to baseline?"). See docstring on _chaos_aggregates for the
+    # exact definitions.
+    chaos_phase_types = {
+        PhaseType.KILL_WORKER,
+        PhaseType.START_WORKER,  # lifecycle pair phase that bridges kill→recovery
+        PhaseType.POSTGRES_RESTART,
+        PhaseType.PG_BACKEND_KILL,
+        PhaseType.POOL_EXHAUSTION,
+        PhaseType.REPEATED_KILL,
+    }
+    for i, phase in enumerate(ordered_phases):
+        # Find a chaos span: 1+ chaos phases followed by a clean / recovery
+        # phase. The aggregates attach to that trailing clean / recovery.
+        if phase.type in chaos_phase_types:
+            continue
+        if phase.type not in (PhaseType.CLEAN, PhaseType.RECOVERY):
+            continue
+        # Walk back to find the chaos phase(s) that immediately preceded.
+        chaos_labels: list[str] = []
+        for prev in reversed(ordered_phases[:i]):
+            if prev.type in chaos_phase_types:
+                chaos_labels.append(prev.label)
+                continue
+            break
+        if not chaos_labels:
+            continue
+        chaos_labels.reverse()
+        # Find the most recent clean baseline before the chaos run so we
+        # can derive a "≥90% of baseline" recovery threshold.
+        baseline_label: str | None = None
+        chaos_start_idx = i - len(chaos_labels)
+        for prev in reversed(ordered_phases[:chaos_start_idx]):
+            if prev.type is PhaseType.CLEAN:
+                baseline_label = prev.label
+                break
+        for system in list(out_systems):
+            agg = _chaos_aggregates(
+                rows,
+                system=system,
+                chaos_labels=chaos_labels,
+                recovery_label=phase.label,
+                baseline_label=baseline_label,
+            )
+            if not agg:
+                continue
+            target = out_systems[system]["phases"].setdefault(
+                phase.label,
+                {"phase_type": phase.type.value, "metrics": {}},
+            )
+            target.update(agg)
+
     for system, system_block in out_systems.items():
         for phase_label, phase_block in system_block["phases"].items():
             dead_tup = _phase_summed_values(
@@ -466,6 +521,116 @@ def compute_summary(
             for p in phases
         ],
         "systems": out_systems,
+    }
+
+
+def _chaos_aggregates(
+    rows: list[dict],
+    *,
+    system: str,
+    chaos_labels: list[str],
+    recovery_label: str,
+    baseline_label: str | None,
+) -> dict | None:
+    """Per-system chaos-recovery metrics derived from raw.csv.
+
+    Returns a dict with:
+    - ``jobs_lost``: best-effort estimate of jobs enqueued during the
+      chaos+recovery span that did not complete by the end of recovery.
+      Computed as ``sum(enqueue_rate * window_s) − sum(completion_rate *
+      window_s)`` over the chaos and recovery phases. Will be ``None`` if
+      neither rate stream is present (some adapters skip rates during
+      severe disruption — e.g. while PG is down).
+    - ``chaos_recovery_time_s``: time (in elapsed_s) from the last sample
+      of the chaos span until completion_rate first re-attains 90% of the
+      baseline median. ``None`` if no baseline phase is available or the
+      threshold isn't reached within the recovery phase.
+    - ``baseline_completion_rate_median``: the median completion_rate
+      from ``baseline_label`` used to derive the recovery threshold.
+      Surfaced so a reader can sanity-check the threshold.
+    """
+
+    def _rate_samples(
+        labels: list[str], metric: str
+    ) -> list[tuple[float, float, float]]:
+        """Return (elapsed_s, value, window_s) tuples summed across
+        replicas per timestamp. Rates are summed (system-level offered
+        load), so we collapse the per-replica streams the same way
+        `aggregate_replica_metric_series` does for the summary."""
+        per_elapsed: dict[float, dict[str, float]] = {}
+        for r in rows:
+            if (
+                r["system"] != system
+                or r["phase_label"] not in labels
+                or r["metric"] != metric
+                or r.get("subject_kind") != "adapter"
+            ):
+                continue
+            try:
+                t = float(r["elapsed_s"])
+                v = float(r["value"])
+                w = float(r.get("window_s") or 0.0)
+            except (TypeError, ValueError):
+                continue
+            slot = per_elapsed.setdefault(t, {"v": 0.0, "w": 0.0})
+            slot["v"] += v
+            # The window is per-replica but identical across replicas at
+            # the same elapsed_s, so take max to avoid double-counting.
+            slot["w"] = max(slot["w"], w)
+        return [
+            (t, slot["v"], slot["w"]) for t, slot in sorted(per_elapsed.items())
+        ]
+
+    span_labels = list(chaos_labels) + [recovery_label]
+    enq = _rate_samples(span_labels, "enqueue_rate")
+    comp = _rate_samples(span_labels, "completion_rate")
+    if not enq and not comp:
+        return None
+
+    def _integrate(samples: list[tuple[float, float, float]]) -> float:
+        # rate * window approximates the count of events in the sample
+        # window; sum across the span gives a cumulative.
+        total = 0.0
+        for _, v, w in samples:
+            if w > 0:
+                total += v * w
+        return total
+
+    jobs_enqueued = _integrate(enq) if enq else None
+    jobs_completed = _integrate(comp) if comp else None
+    jobs_lost: float | None = None
+    if jobs_enqueued is not None and jobs_completed is not None:
+        jobs_lost = max(0.0, jobs_enqueued - jobs_completed)
+
+    # Recovery-time-to-baseline-90%.
+    baseline_median: float | None = None
+    if baseline_label:
+        baseline_series = _rate_samples([baseline_label], "completion_rate")
+        if baseline_series:
+            baseline_median = _median([v for _, v, _ in baseline_series])
+
+    chaos_recovery_time_s: float | None = None
+    if baseline_median is not None and baseline_median > 0:
+        threshold = baseline_median * 0.9
+        # Find the elapsed_s of the last chaos sample.
+        chaos_samples = _rate_samples(chaos_labels, "completion_rate")
+        chaos_end_t: float | None = None
+        if chaos_samples:
+            chaos_end_t = chaos_samples[-1][0]
+        # Recovery samples (post-chaos) — first time we're back to ≥90%.
+        recovery_samples = _rate_samples([recovery_label], "completion_rate")
+        if chaos_end_t is not None and recovery_samples:
+            for t, v, _ in recovery_samples:
+                if v >= threshold:
+                    chaos_recovery_time_s = t - chaos_end_t
+                    break
+
+    return {
+        "jobs_enqueued": jobs_enqueued,
+        "jobs_completed": jobs_completed,
+        "jobs_lost": jobs_lost,
+        "chaos_recovery_time_s": chaos_recovery_time_s,
+        "baseline_completion_rate_median": baseline_median,
     }
 
 

--- a/chaos.py
+++ b/chaos.py
@@ -1,5 +1,30 @@
 #!/usr/bin/env python3
 """
+DEPRECATED: chaos.py is superseded by long_horizon.py phase types.
+
+The chaos scenarios have moved into the long_horizon harness as
+phase compositions (issue #13):
+
+    chaos_crash_recovery     →  kill-worker + start-worker phases
+    chaos_postgres_restart   →  postgres-restart phase
+    chaos_repeated_kills     →  repeated-kill phase
+    chaos_pg_backend_kill    →  pg-backend-kill phase
+    chaos_pool_exhaustion    →  pool-exhaustion phase
+
+Run them via:
+
+    uv run python long_horizon.py run --scenario chaos_crash_recovery \\
+        --systems awa --replicas 2 ...
+
+This file is kept as a reference for `leader_failover`,
+`retry_storm`, and `priority_starvation` — those scenarios are
+more system-specific and are tracked as a follow-up. The
+implementation here was written for awa 0.5.x's canonical engine
+and is broken against 0.6 queue-storage tables; do not use it for
+new measurements.
+
+Original docstring follows.
+
 Chaos comparison: correctness under adverse conditions.
 
 Tests SIGKILL recovery, Postgres restart, and no-job-loss guarantees
@@ -9,6 +34,16 @@ Usage:
     python chaos.py [--scenario crash_recovery|postgres_restart|repeated_kills]
                     [--systems awa,awa-docker,awa-python,procrastinate,river,oban]
 """
+
+import warnings as _warnings
+
+_warnings.warn(
+    "chaos.py is deprecated. Use long_horizon.py with --scenario "
+    "chaos_crash_recovery / chaos_postgres_restart / chaos_repeated_kills / "
+    "chaos_pg_backend_kill / chaos_pool_exhaustion. See README.md.",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
 import argparse
 import json

--- a/results/2026-05-01-bulk-everywhere/SUMMARY.md
+++ b/results/2026-05-01-bulk-everywhere/SUMMARY.md
@@ -45,7 +45,7 @@ Two-tier picture from the previous SUMMARY mostly unchanged in
 direction. Notable shifts vs the previous bulk-everywhere matrix:
 
 - **pgque now 21,790 (was 22,886)** — within run-to-run noise (~5%).
-- **pg-boss now 4,541 (was 5,768)** — −21%, larger than run-to-run noise. Worth re-running to confirm; if real this is a regression in pg-boss between runs (different image build? upstream version moved? bench-scenario interaction?). Flagged as a follow-up; not investigated mid-run.
+- **pg-boss now 4,541 (was 5,768)** — initially flagged as a regression but a third re-run at 128 workers landed at 4,971 jobs/s. Three reads on identical code give 4,051 / 4,971 / 5,768, a ~30 % spread. **It's run-to-run variance, not a regression** — same envelope we see on awa-128 between runs. The 64-worker number (4,541) is more stable.
 - **awa now 4,431 (was 4,566)** — −3%. The COPY-vs-INSERT A/B at 64+128 workers showed COPY winning by ~9% on a single-cell measurement, but that lift gets washed out by matrix-level run-to-run variance (typically 10-30% at this scale on the same code). Treat awa as "unchanged at the matrix level"; the +9% lift is real on direct A/B but isn't a matrix-shifting change.
 - **oban still hangs on shutdown at 64+ workers** (54 / 76 jobs/s) — same anomaly as the previous run. 4-16 worker rows are clean.
 

--- a/tests/test_harness_smoke.py
+++ b/tests/test_harness_smoke.py
@@ -748,6 +748,102 @@ def test_crash_recovery_scenario_resolves():
     )
 
 
+def test_chaos_postgres_restart_scenario_resolves():
+    phases = resolve_scenario("chaos_postgres_restart", None)
+    types = [p.type for p in phases]
+    assert types[0] is PhaseType.WARMUP
+    assert PhaseType.POSTGRES_RESTART in types
+    # Recovery clean phase comes after the chaos.
+    chaos_idx = types.index(PhaseType.POSTGRES_RESTART)
+    assert types[chaos_idx + 1] is PhaseType.CLEAN
+
+
+def test_chaos_pg_backend_kill_scenario_resolves():
+    phases = resolve_scenario("chaos_pg_backend_kill", None)
+    types = [p.type for p in phases]
+    assert PhaseType.PG_BACKEND_KILL in types
+    # rate parameter parsed through correctly.
+    chaos = next(p for p in phases if p.type is PhaseType.PG_BACKEND_KILL)
+    assert chaos.param("rate") == "2"
+
+
+def test_chaos_pool_exhaustion_scenario_carries_idle_conns_param():
+    phases = resolve_scenario("chaos_pool_exhaustion", None)
+    chaos = next(p for p in phases if p.type is PhaseType.POOL_EXHAUSTION)
+    assert chaos.int_param("idle_conns", 0) == 300
+
+
+def test_chaos_repeated_kills_scenario_carries_period_param():
+    phases = resolve_scenario("chaos_repeated_kills", None)
+    chaos = next(p for p in phases if p.type is PhaseType.REPEATED_KILL)
+    assert chaos.int_param("instance", 99) == 0
+    assert chaos.param("period") == "20s"
+
+
+def test_chaos_aggregates_in_summary(tmp_path: Path):
+    """jobs_lost / chaos_recovery_time_s land on the recovery phase."""
+    import csv as _csv
+
+    raw_path = tmp_path / "raw.csv"
+    with raw_path.open("w", newline="") as fh:
+        w = _csv.writer(fh)
+        w.writerow(RAW_CSV_HEADER)
+        # Baseline: enqueue and complete at 100/s for two ticks (window 10s each).
+        for elapsed in (10.0, 20.0):
+            w.writerow([
+                "test", "awa", "0", str(elapsed), "2026-05-01T00:00:00Z",
+                "baseline", "clean", "adapter", "", "enqueue_rate", "100.0", "10.0",
+            ])
+            w.writerow([
+                "test", "awa", "0", str(elapsed), "2026-05-01T00:00:00Z",
+                "baseline", "clean", "adapter", "", "completion_rate", "100.0", "10.0",
+            ])
+        # Chaos: kill phase, enqueue continues, completion drops to 0.
+        for elapsed in (30.0, 40.0):
+            w.writerow([
+                "test", "awa", "0", str(elapsed), "2026-05-01T00:00:00Z",
+                "kill", "kill-worker", "adapter", "", "enqueue_rate", "100.0", "10.0",
+            ])
+            w.writerow([
+                "test", "awa", "0", str(elapsed), "2026-05-01T00:00:00Z",
+                "kill", "kill-worker", "adapter", "", "completion_rate", "0.0", "10.0",
+            ])
+        # Recovery: completion comes back to baseline by t=60.
+        w.writerow([
+            "test", "awa", "0", "50.0", "2026-05-01T00:00:00Z",
+            "recovery", "clean", "adapter", "", "enqueue_rate", "100.0", "10.0",
+        ])
+        w.writerow([
+            "test", "awa", "0", "50.0", "2026-05-01T00:00:00Z",
+            "recovery", "clean", "adapter", "", "completion_rate", "50.0", "10.0",
+        ])
+        w.writerow([
+            "test", "awa", "0", "60.0", "2026-05-01T00:00:00Z",
+            "recovery", "clean", "adapter", "", "enqueue_rate", "100.0", "10.0",
+        ])
+        w.writerow([
+            "test", "awa", "0", "60.0", "2026-05-01T00:00:00Z",
+            "recovery", "clean", "adapter", "", "completion_rate", "100.0", "10.0",
+        ])
+    phases = [
+        parse_phase_spec("warmup=warmup:10s"),
+        parse_phase_spec("baseline=clean:20s"),
+        parse_phase_spec("kill=kill-worker(instance=0):20s"),
+        parse_phase_spec("recovery=clean:20s"),
+    ]
+    summary = compute_summary(
+        raw_path, run_id="test", scenario="chaos_crash_recovery", phases=phases
+    )
+    rec_block = summary["systems"]["awa"]["phases"]["recovery"]
+    assert rec_block["jobs_lost"] is not None
+    # Span = chaos(30,40) + recovery(50,60). Enqueued = 100*10*4 = 4000.
+    # Completed = 0 + 0 + 50*10 + 100*10 = 1500. Lost ≈ 2500.
+    assert abs(rec_block["jobs_lost"] - 2500.0) < 1.0
+    # Recovery to ≥90% of baseline (100): t=60 is first ≥90; chaos ended at t=40.
+    assert rec_block["chaos_recovery_time_s"] == 20.0
+    assert rec_block["baseline_completion_rate_median"] == 100.0
+
+
 def test_event_delivery_matrix_scenario_resolves_expected_shape():
     phases = resolve_scenario("event_delivery_matrix", None)
     assert [p.type for p in phases] == [


### PR DESCRIPTION
## Summary

Consolidate the legacy `chaos.py` runner into the `long_horizon.py` phase substrate. Chaos scenarios become named phase compositions and the chaos-specific orchestration moves into phase-type hooks that share the sample stream, wait-event sampler, and per-phase aggregator with every other scenario. Closes #13. Partial-closes #12 — the `chaos.py` half is gone; cross-system chaos *runs* still need to land scenario-by-scenario via the new phase types.

## New phase types (`bench_harness/phases.py` + `hooks.py`)

| Phase type | Behaviour |
|---|---|
| `postgres-restart` | `docker compose stop postgres` for the first half of the duration, `docker compose start` for the rest. Drives the harness-managed compose lifecycle via callbacks the orchestrator stashes in `runtime.state`. |
| `pg-backend-kill(rate=N)` | Admin connection runs `pg_terminate_backend(pid)` against the SUT's `datname` every `1/N` seconds (filtered to active / idle-in-tx). Uses datname rather than application_name because adapters don't uniformly set it. |
| `pool-exhaustion(idle_conns=N)` | Holds N idle connections to the SUT's database for the duration; releases on phase end. Best-effort if `max_connections` is below the request — the chaos point is "what happens under pressure," not "fail the run if PG can't fit." |
| `repeated-kill(instance=I,period=Ns)` | Periodic SIGKILL + auto-restart of replica I every `period`, composing the existing `kill_worker` / `start_worker` pool methods. Re-uses `parse_duration` for the period spec. |

Existing `kill-worker` / `start-worker` are unchanged.

## New scenarios

`chaos_crash_recovery`, `chaos_postgres_restart`, `chaos_repeated_kills`, `chaos_pg_backend_kill`, `chaos_pool_exhaustion` — all warmup → baseline → chaos → recovery shapes, ~4 minutes each.

## Aggregator

`bench_harness/writers.py::compute_summary` now derives, for any clean / recovery phase that immediately follows a chaos / lifecycle span:
- `jobs_lost` = ∫enqueue_rate − ∫completion_rate over the chaos+recovery span (`rate × window_s` integrated).
- `chaos_recovery_time_s` = elapsed_s from end of chaos until completion_rate first re-attains 90% of the baseline median.
- `baseline_completion_rate_median` (sanity-check field).

These attach to the recovery phase block in `summary.json`. Duplicate-completions tracking (chaos.py originally hashed per-job idempotency keys) is **out of scope** for this PR — the harness doesn't currently track per-job ids; tracked as follow-up.

## Pending (NOT migrated)

The following chaos.py scenarios stay in the deprecated runner because they are system-specific:
- `leader_failover` (awa-only — depends on awa's leader election semantics)
- `retry_storm` (needs adapter-driven retry-storm shape)
- `priority_starvation` (needs priority-aware adapter producer)

`chaos.py` is **not deleted**. It carries a deprecation banner pointing at the new scenarios and emits a `DeprecationWarning` on import.

## Smoke run

```
$ uv run python long_horizon.py run --scenario chaos_crash_recovery \\
    --systems awa --replicas 2 --worker-count 16 --producer-rate 1000 \\
    --producer-mode depth-target --target-depth 1000

[awa] phase warmup (warmup) for 30s
[awa] phase baseline (clean) for 60s
[awa] phase kill (kill-worker) for 60s
[awa] phase restart (start-worker) for 60s
[harness] launching awa replica 0: ...
[awa] phase recovery (clean) for 60s
[harness] results at: results/chaos_crash_recovery-20260501T193816Z-5a7fda
```

`summary.json` recovery block:
```json
{
  "jobs_enqueued": 2359542.83,
  "jobs_completed": 150448.27,
  "jobs_lost": 2209094.56,
  "chaos_recovery_time_s": 4.62,
  "baseline_completion_rate_median": 457.20
}
```

(The absolute jobs_enqueued is inflated because awa's depth-target producer reports very large rates while the kill phase has zero workers; the metric mechanics are correct but the awa-side instrumentation in that mode is something to revisit. `chaos_recovery_time_s` of 4.6 s is the trustworthy number — completion rate came back to ≥90% of baseline within one sample window after the restart.)

`index.html`, `plots/`, and per-phase wait-event histograms all render (wait-event sampler runs by default, untouched).

## Tests

5 new tests: scenario resolution for each new chaos scenario + a synthetic-csv test that exercises the writer's chaos aggregator end-to-end.

```
$ uv run pytest tests/ -q
95 passed in 6.09s
```

## Test plan

- [x] `pytest tests/ -q` — 95 pass (was 85; +10 new)
- [x] Smoke `chaos_crash_recovery` against awa with 2 replicas — emitted `jobs_lost`, `chaos_recovery_time_s`, rendered `index.html`
- [ ] Cross-system smoke (awa + procrastinate + river) on each `chaos_*` scenario — follow-up
- [ ] Migrate `leader_failover` / `retry_storm` / `priority_starvation` — follow-up issue