### PR TITLE
Fix AWA multi-replica metrics

### DIFF
--- a/awa-bench/src/long_horizon.rs
+++ b/awa-bench/src/long_horizon.rs
@@ -609,9 +609,7 @@ pub async fn run() {
                     // AWA_QS_PRODUCER_PATH=batch to A/B back to the
                     // old path for diagnostic comparison.
                     match std::env::var("AWA_QS_PRODUCER_PATH").as_deref() {
-                        Ok("batch") => {
-                            store.enqueue_params_batch(&producer_pool, &params).await
-                        }
+                        Ok("batch") => store.enqueue_params_batch(&producer_pool, &params).await,
                         _ => store.enqueue_params_copy(&producer_pool, &params).await,
                     }
                 }
@@ -671,10 +669,7 @@ pub async fn run() {
                         // queue_lanes.available_count / done_entries /
                         // claim ring instead of scanning ready_entries.
                         // No staleness window needed.
-                        match depth_store
-                            .queue_counts(&depth_pool, queue_name)
-                            .await
-                        {
+                        match depth_store.queue_counts(&depth_pool, queue_name).await {
                             Ok(counts) => {
                                 queue_depth.store(counts.available as u64, Ordering::Relaxed);
                                 running_depth.store(counts.running as u64, Ordering::Relaxed);
@@ -761,8 +756,7 @@ pub async fn run() {
 
         let mut last_enqueued: u64 = sample_enqueued.load(Ordering::Relaxed);
         let mut last_completed: u64 = sample_completed.load(Ordering::Relaxed);
-        let mut last_retryable_failures: u64 =
-            sample_retryable_failures.load(Ordering::Relaxed);
+        let mut last_retryable_failures: u64 = sample_retryable_failures.load(Ordering::Relaxed);
         let mut last_completed_priority_1: u64 =
             sample_completed_priority_1.load(Ordering::Relaxed);
         let mut last_completed_priority_4: u64 =
@@ -771,14 +765,14 @@ pub async fn run() {
             sample_completed_original_priority_1.load(Ordering::Relaxed);
         let mut last_completed_original_priority_4: u64 =
             sample_completed_original_priority_4.load(Ordering::Relaxed);
-        let mut last_aged_completions: u64 =
-            sample_aged_completions.load(Ordering::Relaxed);
+        let mut last_aged_completions: u64 = sample_aged_completions.load(Ordering::Relaxed);
         let mut last_tick = Instant::now();
         let mut ticker = interval_at(
             tokio::time::Instant::now() + Duration::from_secs(sample_every_s),
             Duration::from_secs(sample_every_s),
         );
         ticker.set_missed_tick_behavior(MissedTickBehavior::Delay);
+        let is_producer = producer_enabled();
 
         while !sample_shutdown.load(Ordering::Relaxed) {
             ticker.tick().await;
@@ -799,16 +793,13 @@ pub async fn run() {
             let enq_rate = (enq - last_enqueued) as f64 / dt;
             let cmp_rate = (cmp - last_completed) as f64 / dt;
             let retryable_rate = (retryable - last_retryable_failures) as f64 / dt;
-            let completed_p1_rate =
-                (completed_p1 - last_completed_priority_1) as f64 / dt;
-            let completed_p4_rate =
-                (completed_p4 - last_completed_priority_4) as f64 / dt;
+            let completed_p1_rate = (completed_p1 - last_completed_priority_1) as f64 / dt;
+            let completed_p4_rate = (completed_p4 - last_completed_priority_4) as f64 / dt;
             let completed_original_p1_rate =
                 (completed_original_p1 - last_completed_original_priority_1) as f64 / dt;
             let completed_original_p4_rate =
                 (completed_original_p4 - last_completed_original_priority_4) as f64 / dt;
-            let aged_completion_rate =
-                (aged_completions - last_aged_completions) as f64 / dt;
+            let aged_completion_rate = (aged_completions - last_aged_completions) as f64 / dt;
             last_enqueued = enq;
             last_completed = cmp;
             last_retryable_failures = retryable;
@@ -820,33 +811,21 @@ pub async fn run() {
 
             let window = latency_window;
             let latency_window_s = latency_window.as_secs_f64();
-            let (producer_call_p50, producer_call_p95, producer_call_p99) = {
+            let producer_call_latency = {
                 let mut guard = sample_producer_call_latencies.lock().await;
-                guard
-                    .snapshot(window)
-                    .map(|(a, b, c, _)| (a, b, c))
-                    .unwrap_or((0.0, 0.0, 0.0))
+                guard.snapshot(window).map(|(a, b, c, _)| (a, b, c))
             };
-            let (producer_p50, producer_p95, producer_p99) = {
+            let producer_latency = {
                 let mut guard = sample_producer_latencies.lock().await;
-                guard
-                    .snapshot(window)
-                    .map(|(a, b, c, _)| (a, b, c))
-                    .unwrap_or((0.0, 0.0, 0.0))
+                guard.snapshot(window).map(|(a, b, c, _)| (a, b, c))
             };
-            let (subscriber_p50, subscriber_p95, subscriber_p99) = {
+            let subscriber_latency = {
                 let mut guard = sample_subscriber_latencies.lock().await;
-                guard
-                    .snapshot(window)
-                    .map(|(a, b, c, _)| (a, b, c))
-                    .unwrap_or((0.0, 0.0, 0.0))
+                guard.snapshot(window).map(|(a, b, c, _)| (a, b, c))
             };
-            let (end_to_end_p50, end_to_end_p95, end_to_end_p99) = {
+            let end_to_end_latency = {
                 let mut guard = sample_end_to_end_latencies.lock().await;
-                guard
-                    .snapshot(window)
-                    .map(|(a, b, c, _)| (a, b, c))
-                    .unwrap_or((0.0, 0.0, 0.0))
+                guard.snapshot(window).map(|(a, b, c, _)| (a, b, c))
             };
             let depth = sample_depth.load(Ordering::Relaxed) as f64;
             let running_depth = sample_running_depth.load(Ordering::Relaxed) as f64;
@@ -856,27 +835,117 @@ pub async fn run() {
             let target_rate = sample_target_rate.load(Ordering::Relaxed) as f64;
             let ts = now_iso_ms();
 
+            if is_producer {
+                if let Some((p50, p95, p99)) = producer_call_latency {
+                    for (metric, value) in [
+                        ("producer_call_p50_ms", p50),
+                        ("producer_call_p95_ms", p95),
+                        ("producer_call_p99_ms", p99),
+                    ] {
+                        emit(json!({
+                            "t": ts,
+                            "system": system_name,
+                            "instance_id": instance_id(),
+                            "kind": "adapter",
+                            "subject_kind": "adapter",
+                            "subject": "",
+                            "metric": metric,
+                            "value": value,
+                            "window_s": latency_window_s,
+                        }));
+                    }
+                }
+                if let Some((p50, p95, p99)) = producer_latency {
+                    for (metric, value) in [
+                        ("producer_p50_ms", p50),
+                        ("producer_p95_ms", p95),
+                        ("producer_p99_ms", p99),
+                    ] {
+                        emit(json!({
+                            "t": ts,
+                            "system": system_name,
+                            "instance_id": instance_id(),
+                            "kind": "adapter",
+                            "subject_kind": "adapter",
+                            "subject": "",
+                            "metric": metric,
+                            "value": value,
+                            "window_s": latency_window_s,
+                        }));
+                    }
+                }
+                emit(json!({
+                    "t": ts,
+                    "system": system_name,
+                    "instance_id": instance_id(),
+                    "kind": "adapter",
+                    "subject_kind": "adapter",
+                    "subject": "",
+                    "metric": "enqueue_rate",
+                    "value": enq_rate,
+                    "window_s": sample_every_s as f64,
+                }));
+            }
+
+            if let Some((p50, p95, p99)) = subscriber_latency {
+                for (metric, value) in [
+                    ("subscriber_p50_ms", p50),
+                    ("subscriber_p95_ms", p95),
+                    ("subscriber_p99_ms", p99),
+                    ("claim_p50_ms", p50),
+                    ("claim_p95_ms", p95),
+                    ("claim_p99_ms", p99),
+                ] {
+                    emit(json!({
+                        "t": ts,
+                        "system": system_name,
+                        "instance_id": instance_id(),
+                        "kind": "adapter",
+                        "subject_kind": "adapter",
+                        "subject": "",
+                        "metric": metric,
+                        "value": value,
+                        "window_s": latency_window_s,
+                    }));
+                }
+            }
+            if let Some((p50, p95, p99)) = end_to_end_latency {
+                for (metric, value) in [
+                    ("end_to_end_p50_ms", p50),
+                    ("end_to_end_p95_ms", p95),
+                    ("end_to_end_p99_ms", p99),
+                ] {
+                    emit(json!({
+                        "t": ts,
+                        "system": system_name,
+                        "instance_id": instance_id(),
+                        "kind": "adapter",
+                        "subject_kind": "adapter",
+                        "subject": "",
+                        "metric": metric,
+                        "value": value,
+                        "window_s": latency_window_s,
+                    }));
+                }
+            }
+
             for (metric, value, window_s) in [
-                ("producer_call_p50_ms", producer_call_p50, latency_window_s),
-                ("producer_call_p95_ms", producer_call_p95, latency_window_s),
-                ("producer_call_p99_ms", producer_call_p99, latency_window_s),
-                ("producer_p50_ms", producer_p50, latency_window_s),
-                ("producer_p95_ms", producer_p95, latency_window_s),
-                ("producer_p99_ms", producer_p99, latency_window_s),
-                ("subscriber_p50_ms", subscriber_p50, latency_window_s),
-                ("subscriber_p95_ms", subscriber_p95, latency_window_s),
-                ("subscriber_p99_ms", subscriber_p99, latency_window_s),
-                ("end_to_end_p50_ms", end_to_end_p50, latency_window_s),
-                ("end_to_end_p95_ms", end_to_end_p95, latency_window_s),
-                ("end_to_end_p99_ms", end_to_end_p99, latency_window_s),
-                ("claim_p50_ms", subscriber_p50, latency_window_s),
-                ("claim_p95_ms", subscriber_p95, latency_window_s),
-                ("claim_p99_ms", subscriber_p99, latency_window_s),
-                ("enqueue_rate", enq_rate, sample_every_s as f64),
                 ("completion_rate", cmp_rate, sample_every_s as f64),
-                ("retryable_failure_rate", retryable_rate, sample_every_s as f64),
-                ("completed_priority_1_rate", completed_p1_rate, sample_every_s as f64),
-                ("completed_priority_4_rate", completed_p4_rate, sample_every_s as f64),
+                (
+                    "retryable_failure_rate",
+                    retryable_rate,
+                    sample_every_s as f64,
+                ),
+                (
+                    "completed_priority_1_rate",
+                    completed_p1_rate,
+                    sample_every_s as f64,
+                ),
+                (
+                    "completed_priority_4_rate",
+                    completed_p4_rate,
+                    sample_every_s as f64,
+                ),
                 (
                     "completed_original_priority_1_rate",
                     completed_original_p1_rate,
@@ -887,7 +956,11 @@ pub async fn run() {
                     completed_original_p4_rate,
                     sample_every_s as f64,
                 ),
-                ("aged_completion_rate", aged_completion_rate, sample_every_s as f64),
+                (
+                    "aged_completion_rate",
+                    aged_completion_rate,
+                    sample_every_s as f64,
+                ),
             ] {
                 emit(json!({
                     "t": ts,

--- a/bench_harness/config.py
+++ b/bench_harness/config.py
@@ -59,6 +59,7 @@ class CliConfig(BaseModel):
     target_depth: Annotated[int, Field(ge=1)] = 1000
     worker_count: Annotated[int, Field(ge=1)]
     high_load_multiplier: Annotated[float, Field(gt=0.0)] = 1.5
+    awa_completion_batch_size: Annotated[int | None, Field(ge=1)] = None
     # Replica count per system. 1 is the legacy single-replica mode and
     # the default. `producer_rate` and `worker_count` are per-replica, not
     # per-fleet: N replicas at producer_rate=800 offer 800*N jobs/s in
@@ -136,6 +137,7 @@ class CliConfig(BaseModel):
             target_depth=args.target_depth,
             worker_count=args.worker_count,
             high_load_multiplier=args.high_load_multiplier,
+            awa_completion_batch_size=getattr(args, "awa_completion_batch_size", None),
             replicas=args.replicas,
             wait_events=getattr(args, "wait_events", True),
             wait_event_sample_every=getattr(args, "wait_event_sample_every", 1.0),

--- a/bench_harness/orchestrator.py
+++ b/bench_harness/orchestrator.py
@@ -614,6 +614,7 @@ def run_one_system(
     target_depth: int,
     worker_count: int,
     high_load_multiplier: float,
+    awa_completion_batch_size: int | None = None,
     replicas: int = 1,
     wait_events_enabled: bool = True,
     wait_event_sample_every_s: float = 1.0,
@@ -645,6 +646,8 @@ def run_one_system(
         "TARGET_DEPTH": str(target_depth),
         "WORKER_COUNT": str(worker_count),
     }
+    if awa_completion_batch_size is not None:
+        overrides["AWA_COMPLETION_BATCH_SIZE"] = str(awa_completion_batch_size)
     control_dir = Path(tempfile.mkdtemp(prefix=f"bench-control-{system}-"))
     control_file = control_dir / "producer_rate.txt"
     control_file.write_text(str(producer_rate))
@@ -832,6 +835,7 @@ def drive(
     target_depth: int,
     worker_count: int,
     high_load_multiplier: float,
+    awa_completion_batch_size: int | None,
     replicas: int,
     cli_args: list[str],
     wait_events_enabled: bool = True,
@@ -928,6 +932,7 @@ def drive(
                 target_depth=target_depth,
                 worker_count=worker_count,
                 high_load_multiplier=high_load_multiplier,
+                awa_completion_batch_size=awa_completion_batch_size,
                 replicas=replicas,
                 wait_events_enabled=wait_events_enabled,
                 wait_event_sample_every_s=wait_event_sample_every_s,
@@ -1085,6 +1090,12 @@ def _add_run_arguments(parser: argparse.ArgumentParser) -> None:
         help="Producer-rate multiplier applied during high-load phases (default 1.5).",
     )
     parser.add_argument(
+        "--awa-completion-batch-size",
+        type=int,
+        default=None,
+        help="AWA completion batch size override. Maps to AWA_COMPLETION_BATCH_SIZE.",
+    )
+    parser.add_argument(
         "--replicas",
         type=int,
         default=1,
@@ -1197,6 +1208,7 @@ def _cmd_run(args: argparse.Namespace) -> int:
         target_depth=config.target_depth,
         worker_count=config.worker_count,
         high_load_multiplier=config.high_load_multiplier,
+        awa_completion_batch_size=config.awa_completion_batch_size,
         replicas=config.replicas,
         cli_args=list(sys.argv),
         wait_events_enabled=config.wait_events,

--- a/bench_harness/writers.py
+++ b/bench_harness/writers.py
@@ -15,7 +15,6 @@ import sys
 from dataclasses import asdict
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Iterable
 
 from .phases import (
     PHASE_INCLUDED_IN_SUMMARY,
@@ -146,7 +145,7 @@ def aggregate_replica_metric_series(
             subject_kind=subject_kind,
         )
 
-    per_elapsed: dict[float, list[float]] = {}
+    matched_rows: list[tuple[dict, float]] = []
     for row in rows:
         if (
             row["system"] != system
@@ -157,15 +156,32 @@ def aggregate_replica_metric_series(
         if subject_kind and row["subject_kind"] != subject_kind:
             continue
         try:
-            elapsed_s = float(row["elapsed_s"])
             value = float(row["value"])
         except (TypeError, ValueError):
             continue
-        per_elapsed.setdefault(elapsed_s, []).append(value)
+        matched_rows.append((row, value))
+
+    per_instance: dict[str, list[tuple[float, str, float]]] = {}
+    for row, value in matched_rows:
+        try:
+            elapsed_s = float(row["elapsed_s"])
+        except (TypeError, ValueError):
+            continue
+        instance_id = str(row.get("instance_id") or "")
+        sampled_at = str(row.get("sampled_at") or "")
+        per_instance.setdefault(instance_id, []).append((elapsed_s, sampled_at, value))
+
+    # Adapter processes sample independently, so exact timestamp equality
+    # is too strict across replicas. Coalesce by sample ordinal within each
+    # replica stream, ordered by adapter timestamp then harness elapsed time.
+    per_sample: dict[int, list[float]] = {}
+    for samples in per_instance.values():
+        for idx, (_, _, value) in enumerate(sorted(samples, key=lambda x: (x[1], x[0]))):
+            per_sample.setdefault(idx, []).append(value)
 
     out: list[float] = []
-    for elapsed_s in sorted(per_elapsed):
-        values = per_elapsed[elapsed_s]
+    for sample_idx in sorted(per_sample):
+        values = per_sample[sample_idx]
         if metric in RATE_METRICS:
             out.append(float(sum(values)))
         else:
@@ -554,10 +570,10 @@ def _chaos_aggregates(
         labels: list[str], metric: str
     ) -> list[tuple[float, float, float]]:
         """Return (elapsed_s, value, window_s) tuples summed across
-        replicas per timestamp. Rates are summed (system-level offered
-        load), so we collapse the per-replica streams the same way
-        `aggregate_replica_metric_series` does for the summary."""
-        per_elapsed: dict[float, dict[str, float]] = {}
+        replicas per sample timestamp. Rates are summed (system-level
+        offered load), so we collapse the per-replica streams the same
+        way `aggregate_replica_metric_series` does for the summary."""
+        matched_rows: list[tuple[dict, float, float, float]] = []
         for r in rows:
             if (
                 r["system"] != system
@@ -572,13 +588,31 @@ def _chaos_aggregates(
                 w = float(r.get("window_s") or 0.0)
             except (TypeError, ValueError):
                 continue
-            slot = per_elapsed.setdefault(t, {"v": 0.0, "w": 0.0})
-            slot["v"] += v
-            # The window is per-replica but identical across replicas at
-            # the same elapsed_s, so take max to avoid double-counting.
-            slot["w"] = max(slot["w"], w)
+            matched_rows.append((r, t, v, w))
+
+        per_instance: dict[str, list[tuple[float, str, float, float]]] = {}
+        for r, t, v, w in matched_rows:
+            instance_id = str(r.get("instance_id") or "")
+            sampled_at = str(r.get("sampled_at") or "")
+            per_instance.setdefault(instance_id, []).append((t, sampled_at, v, w))
+
+        per_sample: dict[int, dict[str, float]] = {}
+        for samples in per_instance.values():
+            for idx, (t, _, v, w) in enumerate(
+                sorted(samples, key=lambda x: (x[1], x[0]))
+            ):
+                slot = per_sample.setdefault(idx, {"t": t, "v": 0.0, "w": 0.0})
+                # Keep the earliest harness elapsed time for recovery timing
+                # while coalescing independently ticking adapter replicas by
+                # their sample ordinal.
+                slot["t"] = min(slot["t"], t)
+                slot["v"] += v
+                # The window is per-replica but identical across replicas at
+                # the same sample ordinal, so take max to avoid double-counting.
+                slot["w"] = max(slot["w"], w)
         return [
-            (t, slot["v"], slot["w"]) for t, slot in sorted(per_elapsed.items())
+            (slot["t"], slot["v"], slot["w"])
+            for _, slot in sorted(per_sample.items())
         ]
 
     span_labels = list(chaos_labels) + [recovery_label]

--- a/tests/test_harness_smoke.py
+++ b/tests/test_harness_smoke.py
@@ -116,6 +116,71 @@ def test_summary_on_fixture_excludes_warmup_and_finds_recovery():
     assert phases_out["recovery_1"]["recovery_to_baseline_s"] is not None
 
 
+def test_summary_coalesces_offset_replica_adapter_samples(tmp_path: Path):
+    raw_path = tmp_path / "raw.csv"
+    with raw_path.open("w", newline="") as fh:
+        writer = csv.writer(fh)
+        writer.writerow(RAW_CSV_HEADER)
+        # Two independently ticking adapter replicas. Exact elapsed_s and
+        # sampled_at equality would produce four system samples, not two.
+        for instance_id, offset, sampled_offset_ms, values in [
+            ("0", 0.0, 0, (100.0, 120.0)),
+            ("1", 0.35, 350, (80.0, 90.0)),
+        ]:
+            for idx, value in enumerate(values):
+                elapsed = 10.0 + idx + offset
+                sampled_at = f"2026-05-01T00:00:{10 + idx}.{sampled_offset_ms:03d}Z"
+                writer.writerow([
+                    "test",
+                    "awa",
+                    instance_id,
+                    f"{elapsed:.3f}",
+                    sampled_at,
+                    "clean_1",
+                    "clean",
+                    "adapter",
+                    "",
+                    "completion_rate",
+                    str(value),
+                    "1.0",
+                ])
+        # Worker-only replicas should not need fake zero producer metrics;
+        # this single producer stream should survive unchanged.
+        for idx, value in enumerate((200.0, 200.0)):
+            writer.writerow([
+                "test",
+                "awa",
+                "0",
+                f"{10.0 + idx:.3f}",
+                f"2026-05-01T00:00:{10 + idx}.000Z",
+                "clean_1",
+                "clean",
+                "adapter",
+                "",
+                "enqueue_rate",
+                str(value),
+                "1.0",
+            ])
+
+    summary = compute_summary(
+        raw_path,
+        run_id="test",
+        scenario=None,
+        phases=[parse_phase_spec("clean_1=clean:2s")],
+    )
+    block = summary["systems"]["awa"]["phases"]["clean_1"]
+    assert block["metrics"]["completion_rate"] == {
+        "median": 195.0,
+        "peak": 210.0,
+        "count": 2,
+    }
+    assert block["metrics"]["enqueue_rate"] == {
+        "median": 200.0,
+        "peak": 200.0,
+        "count": 2,
+    }
+
+
 # ─── Plots ──────────────────────────────────────────────────────────
 
 def test_lttb_preserves_endpoints():
@@ -204,6 +269,7 @@ def _config_kwargs(**overrides):
         target_depth=1000,
         worker_count=32,
         high_load_multiplier=1.5,
+        awa_completion_batch_size=None,
     )
     base.update(overrides)
     return base
@@ -267,6 +333,16 @@ def test_config_rejects_zero_worker_count():
 def test_config_producer_mode_literal():
     with pytest.raises(ValidationError):
         CliConfig(**_config_kwargs(producer_mode="nope"))
+
+
+def test_config_accepts_awa_completion_batch_size():
+    config = CliConfig(**_config_kwargs(awa_completion_batch_size=128))
+    assert config.awa_completion_batch_size == 128
+
+
+def test_config_rejects_non_positive_awa_completion_batch_size():
+    with pytest.raises(ValidationError):
+        CliConfig(**_config_kwargs(awa_completion_batch_size=0))
 
 
 def test_format_validation_error_is_readable():
@@ -471,6 +547,20 @@ def test_argparse_replicas_flag():
     # Default survives when flag is absent.
     ns = p.parse_args(["run", "--scenario", "idle_in_tx_saturation"])
     assert ns.replicas == 1
+
+
+def test_argparse_awa_completion_batch_size_flag():
+    from bench_harness.orchestrator import build_parser
+
+    p = build_parser()
+    ns = p.parse_args([
+        "run",
+        "--scenario",
+        "idle_in_tx_saturation",
+        "--awa-completion-batch-size",
+        "128",
+    ])
+    assert ns.awa_completion_batch_size == 128
 
 
 # ── ReplicaPool state machine ───────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes AWA benchmark reporting for multi-replica runs where adapter processes sample independently.

- aggregate system-level replica streams by sample ordinal within each replica stream instead of exact `elapsed_s` equality
- keep chaos/recovery rate aggregation on the same coalescing rule
- stop worker-only AWA replicas from emitting synthetic producer latency/enqueue metrics when `PRODUCER_ONLY_INSTANCE_ZERO=1`
- suppress empty latency-window zero samples so idle/non-producer replicas do not dilute p99s

Depth polling remains observer-only, as before.

## Validation

- `cargo fmt --manifest-path awa-bench/Cargo.toml -- --check`
- `uv run --extra dev pytest tests/test_harness_smoke.py -q` (`95 passed`)
- two-replica AWA smoke:

```bash
PRODUCER_ONLY_INSTANCE_ZERO=1 AWA_COMPLETION_SHARDS=4 AWA_COMPLETION_BATCH_SIZE=128 \
  uv run bench run --skip-build --systems awa --replicas 2 --worker-count 16 \
  --producer-rate 200 --phase warm=warmup:2s --phase clean=clean:4s \
  --sample-every 1 --no-wait-events
```

Clean phase summary from `results/custom-20260502T012524Z-b89e38`:

- aggregate `completion_rate`: median 190.1/s, peak 205.0/s, count 5
- aggregate `enqueue_rate`: median 200.0/s, peak 200.0/s, count 5
- worker-only replica producer metrics are null/count 0, not fake zero samples

This makes the AWA completion batch-size / worker-process matrix much easier to interpret.
