### PR TITLE
Add Postgres load diagnostics sampling

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ to `bench.py run`, or compose your own with `--phase
 | `pool-exhaustion(idle_conns=N)` | Holds `N` idle connections against the SUT's database for the duration; releases them on phase end. |
 | `repeated-kill(instance=I,period=Ns)` | Periodic SIGKILL + auto-restart of replica `I` every `period`. Composes `kill-worker` / `start-worker`. |
 
-## Wait-event sampling
+## Postgres Diagnostics
 
 Throughput, latency, and bloat answer *that* one system is slower than
 another. **Wait events** answer *why* — the postgres-side reason a
@@ -271,12 +271,20 @@ aggregates non-idle backend snapshots into a per-phase histogram of
 [pg_ash](https://github.com/NikolayS/pg_ash) produces, implemented
 inside the harness so we don't have to swap the postgres image.
 
-Output lands in `raw.csv` (`subject_kind=wait_event`), `summary.json`
-(top-10 events per phase plus `total_active_samples`), and a stacked
-bar plot per system in `index.html`. On by default at 1 s cadence;
-opt out with `--no-wait-events` or tune via
-`--wait-event-sample-every <seconds>`. Primer with the common event
-types and how to read the stack: [`docs/wait-events.md`](docs/wait-events.md).
+The metrics daemon also records `pg_notification_queue_usage()` and active
+transaction context from `pg_stat_activity` during load. Notification queue
+usage lands in `raw.csv` as the cluster metric
+`pg_notification_queue_usage`; active transaction rows land as
+`subject_kind=pg_activity` with `xact_age_s` as the numeric value and the
+backend pid, application name, state, `xact_start`, wait event, and compacted
+query text encoded in the subject.
+
+Wait-event output lands in `raw.csv` (`subject_kind=wait_event`),
+`summary.json` (top-10 events per phase plus `total_active_samples`), and a
+stacked bar plot per system in `index.html`. Wait-event sampling is on by
+default at 1 s cadence; opt out with `--no-wait-events` or tune via
+`--wait-event-sample-every <seconds>`. Primer with the common event types and
+how to read the stack: [`docs/wait-events.md`](docs/wait-events.md).
 
 ## Repo layout
 

--- a/bench_harness/metrics.py
+++ b/bench_harness/metrics.py
@@ -10,7 +10,9 @@ regardless of when each system's run started within that second.
 
 from __future__ import annotations
 
+import json
 import queue
+import re
 import sys
 import threading
 import time
@@ -87,6 +89,26 @@ CROSS JOIN pg_stat_activity
 GROUP BY snap.snapshot_xmin
 """
 
+_NOTIFICATION_QUEUE_USAGE_SQL = """
+SELECT pg_notification_queue_usage()::double precision
+"""
+
+_ACTIVE_XACT_SQL = """
+SELECT
+  pid,
+  application_name,
+  state,
+  xact_start,
+  EXTRACT(EPOCH FROM (now() - xact_start))::double precision AS xact_age_s,
+  wait_event_type,
+  wait_event,
+  query
+FROM pg_stat_activity
+WHERE xact_start IS NOT NULL
+  AND pid <> pg_backend_pid()
+ORDER BY xact_start
+"""
+
 _PGSTATTUPLE_SQL = """
 SELECT dead_tuple_percent, free_percent
 FROM pgstattuple(%s)
@@ -100,6 +122,55 @@ FROM pgstatindex(%s)
 
 def _is_missing_relation(exc: psycopg.Error) -> bool:
     return exc.sqlstate in {"42P01", "42704"}
+
+
+def _compact_query_text(query: object, *, max_len: int = 1000) -> str:
+    """Normalize pg_stat_activity.query for compact raw.csv storage."""
+    if query is None:
+        return ""
+    text = re.sub(r"\s+", " ", str(query)).strip()
+    if len(text) <= max_len:
+        return text
+    return text[: max_len - 1] + "…"
+
+
+def activity_subject(
+    *,
+    pid: int,
+    application_name: object,
+    state: object,
+    xact_start: object,
+    wait_event_type: object,
+    wait_event: object,
+    query: object,
+) -> str:
+    """Encode active-transaction context in a stable raw.csv subject string.
+
+    ``Sample.value`` stays numeric (``xact_age_s``), while the requested
+    pg_stat_activity columns that are descriptive rather than numeric live in
+    the subject as compact JSON. Keeping the shape in raw.csv avoids adding a
+    second output format while preserving the query attribution needed during
+    load-run triage.
+    """
+    if hasattr(xact_start, "isoformat"):
+        xact_start_value = xact_start.isoformat()
+    elif xact_start is None:
+        xact_start_value = None
+    else:
+        xact_start_value = str(xact_start)
+    return json.dumps(
+        {
+            "pid": int(pid),
+            "application_name": application_name or "",
+            "state": state or "",
+            "xact_start": xact_start_value,
+            "wait_event_type": wait_event_type,
+            "wait_event": wait_event,
+            "query": _compact_query_text(query),
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
 
 
 class MetricsDaemon(threading.Thread):
@@ -394,6 +465,56 @@ class MetricsDaemon(threading.Thread):
                     subject="",
                     metric="oldest_idle_in_tx_age_s",
                     value=float(oldest_idle_age),
+                )
+
+            try:
+                cur.execute(_NOTIFICATION_QUEUE_USAGE_SQL)
+                row = cur.fetchone()
+            except psycopg.Error:
+                row = None
+            if row is not None:
+                self._emit(
+                    subject_kind="cluster",
+                    subject="",
+                    metric="pg_notification_queue_usage",
+                    value=float(row[0]),
+                )
+
+            try:
+                cur.execute(_ACTIVE_XACT_SQL)
+                rows = cur.fetchall()
+            except psycopg.Error:
+                rows = []
+            self._emit(
+                subject_kind="cluster",
+                subject="",
+                metric="active_xact_count",
+                value=float(len(rows)),
+            )
+            for activity in rows:
+                (
+                    pid,
+                    application_name,
+                    state,
+                    xact_start,
+                    xact_age_s,
+                    wait_event_type,
+                    wait_event,
+                    query,
+                ) = activity
+                self._emit(
+                    subject_kind="pg_activity",
+                    subject=activity_subject(
+                        pid=pid,
+                        application_name=application_name,
+                        state=state,
+                        xact_start=xact_start,
+                        wait_event_type=wait_event_type,
+                        wait_event=wait_event,
+                        query=query,
+                    ),
+                    metric="xact_age_s",
+                    value=float(xact_age_s),
                 )
 
     # ── emission helpers ───────────────────────────────────────────────

--- a/bench_harness/writers.py
+++ b/bench_harness/writers.py
@@ -308,6 +308,12 @@ def compute_summary(
             # (top-N histogram per phase) and don't fit the generic
             # (median, peak, count) shape — skip them in the bucket pass.
             continue
+        if row.get("subject_kind") == "pg_activity":
+            # Rich active-transaction rows intentionally carry query text
+            # and backend identity in `subject`. They are raw diagnostics,
+            # not summary dimensions; including them here would create a
+            # giant per-query metrics map in summary.json.
+            continue
         instance_id = row.get("instance_id") or ""
         key = (
             row["system"],

--- a/docs/wait-events.md
+++ b/docs/wait-events.md
@@ -99,14 +99,16 @@ samples during the clean phase. Quick interpretation guide:
 - 1 s sampling cadence misses sub-second contention bursts. Drop
   `--wait-event-sample-every` to e.g. 0.25 if you suspect short-lived
   spikes; the overhead is still negligible.
-- We don't capture `query` text. That would let us attribute waits
-  to specific queries (claim vs ack vs cleanup) but `pg_stat_activity`
-  truncates at `track_activity_query_size` and the cardinality
-  explodes the storage. Follow-up: see issue tagged
-  `wait-events-query-attribution`.
-- Single-PID samples — we don't track `xact_start`, so we can't
-  derive *durations*, only sample counts. Counts are a good enough
-  proxy at fixed cadence.
+- Wait-event rows are still aggregated by `(wait_event_type, wait_event)`,
+  so they do not carry query text. The metrics daemon separately records
+  active transactions in `raw.csv` as `subject_kind=pg_activity`, with
+  `xact_age_s` as the value and pid, application name, state, `xact_start`,
+  wait event, and compacted query text encoded in the subject.
+- `pg_stat_activity.query` is truncated by Postgres at
+  `track_activity_query_size`; the harness also compacts whitespace and
+  caps the stored text so raw samples remain usable over long runs.
+- Notification queue pressure is sampled as the cluster metric
+  `pg_notification_queue_usage`.
 
 ## Disabling
 

--- a/tests/test_harness_smoke.py
+++ b/tests/test_harness_smoke.py
@@ -1023,6 +1023,7 @@ from bench_harness.wait_events import (
     WaitEventSampler,
     aggregate_rows,
 )
+from bench_harness.metrics import activity_subject
 
 
 def test_aggregate_rows_buckets_by_event_pair():
@@ -1150,6 +1151,31 @@ def test_sampler_isolates_phases():
     assert rows[0].wait_event == "tuple"
 
 
+def test_activity_subject_preserves_transaction_context():
+    import json
+    from datetime import datetime, timezone
+
+    subject = activity_subject(
+        pid=123,
+        application_name="pgque-worker",
+        state="active",
+        xact_start=datetime(2026, 5, 8, 0, 0, 0, tzinfo=timezone.utc),
+        wait_event_type="Lock",
+        wait_event="transactionid",
+        query="SELECT  *\nFROM   pgque.receive('orders', 'consumer', 100)",
+    )
+    payload = json.loads(subject)
+    assert payload == {
+        "pid": 123,
+        "application_name": "pgque-worker",
+        "state": "active",
+        "xact_start": "2026-05-08T00:00:00+00:00",
+        "wait_event_type": "Lock",
+        "wait_event": "transactionid",
+        "query": "SELECT * FROM pgque.receive('orders', 'consumer', 100)",
+    }
+
+
 def test_summary_includes_wait_event_block(tmp_path: Path):
     # Cook up a raw.csv with both adapter rows and harness wait-event
     # rows, then run compute_summary and confirm the wait_events block
@@ -1182,6 +1208,20 @@ def test_summary_includes_wait_event_block(tmp_path: Path):
             "clean_1", "clean", "wait_event", "__total__",
             "total_active_samples", "42.0", "60.0",
         ])
+        # Rich pg_stat_activity rows are raw diagnostics. They should stay
+        # out of summary.json so query text does not become a giant metric key.
+        writer.writerow([
+            "test", "awa", "0", "61.0", "2026-05-01T00:01:01Z",
+            "clean_1", "clean", "pg_activity", '{"query":"SELECT 1"}',
+            "xact_age_s", "3.5", "0.0",
+        ])
+        # Notification pressure is a numeric cluster metric and should be
+        # summarized like the other cluster diagnostics.
+        writer.writerow([
+            "test", "awa", "0", "61.0", "2026-05-01T00:01:01Z",
+            "clean_1", "clean", "cluster", "",
+            "pg_notification_queue_usage", "0.125", "0.0",
+        ])
     phases = [parse_phase_spec("clean_1=clean:60s")]
     summary = compute_summary(
         raw_path, run_id="test", scenario=None, phases=phases
@@ -1196,6 +1236,9 @@ def test_summary_includes_wait_event_block(tmp_path: Path):
     assert we["top"][1] == {
         "event_type": "Lock", "event": "tuple", "count": 12,
     }
+    metrics = block["metrics"]
+    assert "pg_notification_queue_usage" in metrics
+    assert "xact_age_s@{\"query\":\"SELECT 1\"}" not in metrics
 
 
 def test_cliconfig_wait_event_defaults():


### PR DESCRIPTION
## Summary
- sample `pg_notification_queue_usage()` as a cluster metric during harness runs
- record active transaction rows from `pg_stat_activity` as raw `pg_activity` diagnostics with xact age and compacted query context
- keep rich pg_activity rows out of `summary.json` while documenting the new raw.csv shape

## Validation
- `python3 -m compileall bench_harness tests/test_harness_smoke.py`
- `uv run --extra dev pytest tests/test_harness_smoke.py -q`
