### PR TITLE
docs: note absurd-sdk 0.4.0 retry-count fallback fix

### DIFF
--- a/docs/method.md
+++ b/docs/method.md
@@ -41,6 +41,20 @@ Awa-only experiments:
 | `AWA_QUEUE_CLAIMERS` | `1` | Queue-storage dispatcher/claimer loops per logical queue. Claimers share that queue's worker permits. |
 | `AWA_CLAIM_BATCH_SIZE` | `512` | Maximum jobs each claimer attempts to claim in one database round trip. |
 
+## Adapter version notes
+
+Caveats from upstream version bumps that change benchmark semantics but
+aren't visible from the version number alone:
+
+- **absurd-bench**: `absurd-sdk` 0.4.0 fixed a bug where a task registered
+  without an explicit `max_attempts` didn't correctly fall back to the
+  `AsyncAbsurd` app's `default_max_attempts`. The adapter's
+  `register_task(TASK_NAME)` call has never set `max_attempts` explicitly,
+  so this bump silently changes its effective retry count from whatever the
+  prior buggy fallback resolved to, to the correct `default_max_attempts=5`.
+  No adapter code change needed, but keep this in mind when comparing
+  retry/DLQ behavior against runs from before the 0.4.0 bump.
+
 ## Phase types (compose your own)
 
 | Phase type | What it does |


### PR DESCRIPTION
## Summary

Small follow-up to #35 (queue-system adapter version bumps). While verifying that PR, I confirmed one more benchmark-relevant detail worth documenting: `absurd-sdk` 0.4.0 fixed a bug where a task registered without an explicit `max_attempts` didn't correctly fall back to the app's `default_max_attempts`. `absurd-bench`'s `register_task(TASK_NAME)` call has never set `max_attempts` explicitly, so the 0.4.0 bump silently changes its effective retry count from whatever the prior buggy fallback resolved to, to the correct `default_max_attempts=5`.

No adapter code change is needed (the adapter's usage was always "correct" — the bug was upstream), but this could otherwise look like an unexplained behavior shift when comparing retry/DLQ metrics against runs recorded before the #35 bump. Documented in `docs/method.md` under a new "Adapter version notes" section.

## Note: no lockfiles in this PR

I initially planned to also add regenerated `uv.lock` files for `procrastinate-bench` and `absurd-bench`. Turns out `.gitignore` deliberately excludes `*-bench/uv.lock` (and `*-bench/mix.lock`) repo-wide, with a comment explaining these per-adapter Python/Elixir lockfiles aren't part of the tracked contract — only Rust `Cargo.lock` and Node `package-lock.json` are tracked at the adapter level, plus the root harness `uv.lock`. Since both adapters already pin exact versions (`==`) in `pyproject.toml`, I left this alone rather than fight that convention. Verified `uv sync`/`docker build` resolve cleanly against the post-#35 pins (procrastinate 3.9.0, absurd-sdk 0.4.0) regardless.

## Verification

- `uv run pytest --import-mode=importlib` — 106 passed
- `docker build` for `procrastinate-bench` and `absurd-bench` against current `pyproject.toml` pins — both succeed