### PR TITLE
feat: AlloyDB Omni engine axis + idle_background_cost scenario

### DIFF
--- a/bench_harness/adapters.py
+++ b/bench_harness/adapters.py
@@ -26,7 +26,40 @@ REPO_ROOT = SCRIPT_DIR
 PG_PORT = 15555
 PG_USER = "bench"
 PG_PASS = "bench"
-DEFAULT_PG_IMAGE = "postgres:18.3-alpine"
+
+
+@dataclass(frozen=True)
+class Engine:
+    """A Postgres-compatible storage engine the harness can benchmark on.
+
+    ``image`` is the container image; ``compose_override`` is an optional
+    repo-root-relative compose file merged via ``-f`` only for this engine
+    (so the default postgres run keeps the implicit
+    ``docker-compose.override.yml`` auto-merge behaviour).
+    """
+
+    image: str
+    compose_override: str | None = None
+
+
+# Engine registry. The default is stock Postgres; AlloyDB Omni is the same
+# major (18.3) but a different storage engine — its relation-file lifecycle
+# (TRUNCATE/relfilenode churn) is materially costlier, which the
+# idle_background_cost scenario is designed to surface. Omni needs a compose
+# override because the base compose `command` pins `config_file=`, which would
+# otherwise bypass Omni's generated `shared_preload_libraries` and silently
+# disable its engine. The preload list was captured from the stock image
+# (`SHOW shared_preload_libraries`).
+ENGINES: dict[str, "Engine"] = {
+    "postgres": Engine(image="postgres:18.3-alpine"),
+    "alloydb-omni": Engine(
+        image="gcr.io/alloydb-omni/alloydbomni:18.3",
+        compose_override="docker-compose.omni.override.yml",
+    ),
+}
+DEFAULT_ENGINE = "postgres"
+# Preserved name: several modules import DEFAULT_PG_IMAGE directly.
+DEFAULT_PG_IMAGE = ENGINES[DEFAULT_ENGINE].image
 
 
 def pg_url(dbname: str, host: str = "localhost") -> str:

--- a/bench_harness/compare.py
+++ b/bench_harness/compare.py
@@ -69,6 +69,25 @@ def render(summary: dict, out_path: Path, *, phase: str = "clean_1") -> None:
     if not systems:
         raise SystemExit("summary has no systems")
 
+    # Fall back to the first summarized phase when the requested label isn't
+    # in this run. Scenarios name their measurement phase differently
+    # (idle_background_cost summarizes `idle_1`, the CLI default is
+    # `clean_1`); without this, the whole comparison renders empty cells
+    # unless the caller remembers --phase.
+    available = [
+        p["label"] for p in summary.get("phases", [])
+        if any(
+            p.get("label") in summary["systems"][s].get("phases", {})
+            for s in systems
+        )
+    ]
+    if phase not in available and available:
+        print(
+            f"[compare] phase {phase!r} not in this run; using {available[0]!r}",
+            file=sys.stderr,
+        )
+        phase = available[0]
+
     lines: list[str] = []
     lines.append("# Cross-System Comparison")
     lines.append("")
@@ -167,7 +186,10 @@ def render(summary: dict, out_path: Path, *, phase: str = "clean_1") -> None:
         "these isolate the queue's own maintenance chatter. "
         "**Relfilenode churn/s** counts on-disk file swaps — the signature "
         "of `TRUNCATE` / `VACUUM FULL` / `REINDEX` / rewrite; a queue that "
-        "reclaims by re-truncating idle segments shows a non-zero rate here."
+        "reclaims by re-truncating idle segments shows a non-zero rate here. "
+        "Background xacts include a small constant harness floor — one "
+        "transaction per metrics tick plus ~1/s from the wait-event sampler "
+        "— identical for every system, so cross-system deltas are clean."
     )
     lines.append("")
     lines.append(

--- a/bench_harness/compare.py
+++ b/bench_harness/compare.py
@@ -142,6 +142,48 @@ def render(summary: dict, out_path: Path, *, phase: str = "clean_1") -> None:
         lines.append(f"| {sys_name} | {med:,} | {peak:,} |")
     lines.append("")
 
+    # Idle background cost. Most meaningful for the idle_background_cost
+    # scenario (run at --producer-rate 0), where these isolate each engine's
+    # own maintenance cost. The fields live directly on the phase block
+    # (see writers.compute_summary), not under "metrics".
+    def _phase_block(sys_name: str) -> dict:
+        return summary["systems"][sys_name].get("phases", {}).get(phase, {})
+
+    def _fmt_rate(v: Any) -> str:
+        if v is None:
+            return "—"
+        if isinstance(v, (int, float)):
+            if abs(v) >= 1000:
+                return f"{v:,.0f}"
+            return f"{v:,.3f}"
+        return str(v)
+
+    lines.append("## Idle background cost")
+    lines.append("")
+    lines.append(
+        "Postgres-side cost of each engine's background runtime over `"
+        f"{phase}`, normalized per second. Most meaningful for the "
+        "`idle_background_cost` scenario (offered load driven to zero): "
+        "these isolate the queue's own maintenance chatter. "
+        "**Relfilenode churn/s** counts on-disk file swaps — the signature "
+        "of `TRUNCATE` / `VACUUM FULL` / `REINDEX` / rewrite; a queue that "
+        "reclaims by re-truncating idle segments shows a non-zero rate here."
+    )
+    lines.append("")
+    lines.append(
+        "| System | WAL bytes/s | Relfilenode churn/s | Background xacts/s |"
+    )
+    lines.append("|---|---:|---:|---:|")
+    for sys_name in systems:
+        pb = _phase_block(sys_name)
+        lines.append(
+            f"| {sys_name} "
+            f"| {_fmt_rate(pb.get('pg_wal_bytes_per_s'))} "
+            f"| {_fmt_rate(pb.get('relfilenode_churn_per_s'))} "
+            f"| {_fmt_rate(pb.get('pg_db_xacts_per_s'))} |"
+        )
+    lines.append("")
+
     # Caveats.
     lines.append("## Caveats")
     lines.append("")

--- a/bench_harness/config.py
+++ b/bench_harness/config.py
@@ -22,7 +22,7 @@ from pydantic import (
     model_validator,
 )
 
-from .adapters import ADAPTERS, DEFAULT_PG_IMAGE
+from .adapters import ADAPTERS, DEFAULT_ENGINE, DEFAULT_PG_IMAGE, ENGINES
 from .phases import Phase, SCENARIOS, resolve_scenario
 
 
@@ -46,6 +46,7 @@ class CliConfig(BaseModel):
     systems: list[str]
 
     # ── Environment ────────────────────────────────────────────────────
+    engine: str = DEFAULT_ENGINE
     pg_image: str = DEFAULT_PG_IMAGE
     fast: bool = False
     skip_build: bool = False
@@ -74,6 +75,14 @@ class CliConfig(BaseModel):
     # (< 0.1% of one core at 1 s cadence). See bench_harness/wait_events.py.
     wait_events: bool = True
     wait_event_sample_every: Annotated[float, Field(gt=0.0)] = 1.0
+
+    @field_validator("engine")
+    @classmethod
+    def _engine_must_be_known(cls, v: str) -> str:
+        if v in ENGINES:
+            return v
+        known = ", ".join(sorted(ENGINES))
+        raise ValueError(f"unknown engine {v!r}; known: {known}")
 
     @field_validator("scenario")
     @classmethod
@@ -124,11 +133,17 @@ class CliConfig(BaseModel):
     def from_namespace(cls, args: argparse.Namespace) -> "CliConfig":
         """Build from argparse output. Maps flag names to model fields."""
         systems = [s.strip() for s in args.systems.split(",") if s.strip()]
+        engine = getattr(args, "engine", DEFAULT_ENGINE)
+        # --pg-image (default None) overrides the engine's default image;
+        # otherwise take the selected engine's image.
+        engine_default_image = ENGINES[engine].image if engine in ENGINES else DEFAULT_PG_IMAGE
+        pg_image = getattr(args, "pg_image", None) or engine_default_image
         return cls(
             scenario=args.scenario,
             phase_specs=list(args.phase or []),
             systems=systems,
-            pg_image=args.pg_image,
+            engine=engine,
+            pg_image=pg_image,
             fast=args.fast,
             skip_build=args.skip_build,
             sample_every=args.sample_every,

--- a/bench_harness/metrics.py
+++ b/bench_harness/metrics.py
@@ -17,7 +17,6 @@ import sys
 import threading
 import time
 from dataclasses import dataclass
-from typing import Iterable
 
 import psycopg
 
@@ -383,10 +382,42 @@ class MetricsDaemon(threading.Thread):
         self._tick_elapsed_s = round(time.time() - self.bench_start, 3)
         self._tick_sampled_at = now_iso()
         try:
-            self._poll_once_body(conn)
+            # One explicit transaction per tick (the connection is otherwise
+            # autocommit, i.e. one counted transaction per statement). This
+            # matters for pg_db_xacts_total: the daemon's own statement count
+            # scales with the adapter's event_tables/indexes list, so under
+            # autocommit the harness would inflate the "background xacts"
+            # metric by a different amount per system. One txn/tick makes the
+            # harness's contribution a constant across every adapter.
+            with conn.transaction():
+                self._poll_once_body(conn)
         finally:
             self._tick_elapsed_s = None
             self._tick_sampled_at = None
+
+    def _tick_query(
+        self,
+        conn: "psycopg.Connection",
+        cur: "psycopg.Cursor",
+        sql: str,
+        params: tuple | None = None,
+        *,
+        fetchall: bool = False,
+    ):
+        """Run one query of the tick under a savepoint; None on error.
+
+        The tick runs inside a single transaction (see _poll_once), so a
+        failing query would poison every later query of the tick with
+        InFailedSqlTransaction. The nested ``conn.transaction()`` block is a
+        savepoint: an individual failure rolls back only itself, preserving
+        the old autocommit behaviour where each probe degraded independently.
+        """
+        try:
+            with conn.transaction():
+                cur.execute(sql, params)
+                return cur.fetchall() if fetchall else cur.fetchone()
+        except psycopg.Error:
+            return None
 
     def _poll_once_body(self, conn: "psycopg.Connection") -> None:
         with conn.cursor() as cur:
@@ -394,13 +425,9 @@ class MetricsDaemon(threading.Thread):
                 schema, _, relname = fq_table.partition(".")
                 if not relname:
                     continue
-                try:
-                    cur.execute(_TABLE_STATS_SQL, (schema, relname))
-                    row = cur.fetchone()
-                except psycopg.Error:
-                    continue
+                row = self._tick_query(conn, cur, _TABLE_STATS_SQL, (schema, relname))
                 if row is None:
-                    # Not yet created by the adapter — skip this tick.
+                    # Errored, or not yet created by the adapter — skip this tick.
                     continue
                 (
                     n_dead,
@@ -448,11 +475,7 @@ class MetricsDaemon(threading.Thread):
                     value=float(table_mb),
                 )
             for fq_index in self.targets.event_indexes:
-                try:
-                    cur.execute(_INDEX_SIZE_SQL, (fq_index,))
-                    row = cur.fetchone()
-                except psycopg.Error:
-                    continue
+                row = self._tick_query(conn, cur, _INDEX_SIZE_SQL, (fq_index,))
                 if row is None:
                     continue
                 self._emit(
@@ -462,11 +485,7 @@ class MetricsDaemon(threading.Thread):
                     value=float(row[0]),
                 )
 
-            try:
-                cur.execute(_CLUSTER_SQL)
-                row = cur.fetchone()
-            except psycopg.Error:
-                row = None
+            row = self._tick_query(conn, cur, _CLUSTER_SQL)
             if row is not None:
                 (
                     snapshot_xmin,
@@ -506,11 +525,7 @@ class MetricsDaemon(threading.Thread):
                     value=float(oldest_idle_age),
                 )
 
-            try:
-                cur.execute(_NOTIFICATION_QUEUE_USAGE_SQL)
-                row = cur.fetchone()
-            except psycopg.Error:
-                row = None
+            row = self._tick_query(conn, cur, _NOTIFICATION_QUEUE_USAGE_SQL)
             if row is not None:
                 self._emit(
                     subject_kind="cluster",
@@ -519,11 +534,7 @@ class MetricsDaemon(threading.Thread):
                     value=float(row[0]),
                 )
 
-            try:
-                cur.execute(_PG_STAT_WAL_SQL)
-                row = cur.fetchone()
-            except psycopg.Error:
-                row = None
+            row = self._tick_query(conn, cur, _PG_STAT_WAL_SQL)
             if row is not None:
                 wal_records, wal_fpi, wal_bytes = row
                 self._emit(
@@ -550,11 +561,10 @@ class MetricsDaemon(threading.Thread):
             # swapped (TRUNCATE / VACUUM FULL / REINDEX / rewrite). Emitted as
             # a monotonic cluster counter so the per-phase delta and rate fall
             # out of the standard counter-delta aggregation.
-            try:
-                cur.execute(_RELFILENODE_SQL)
-                current = {rel: node for rel, node in cur.fetchall()}
-            except psycopg.Error:
-                current = None
+            rel_rows = self._tick_query(conn, cur, _RELFILENODE_SQL, fetchall=True)
+            current = (
+                {rel: node for rel, node in rel_rows} if rel_rows is not None else None
+            )
             if current is not None:
                 if self._relfilenode_prev:
                     for rel, node in current.items():
@@ -570,11 +580,7 @@ class MetricsDaemon(threading.Thread):
                 )
 
             # Per-database transaction / tuple churn (background chattiness).
-            try:
-                cur.execute(_PG_STAT_DATABASE_SQL)
-                row = cur.fetchone()
-            except psycopg.Error:
-                row = None
+            row = self._tick_query(conn, cur, _PG_STAT_DATABASE_SQL)
             if row is not None:
                 db_xacts, db_tup_updated, db_tup_deleted = row
                 self._emit(
@@ -596,11 +602,7 @@ class MetricsDaemon(threading.Thread):
                     value=float(db_tup_deleted),
                 )
 
-            try:
-                cur.execute(_ACTIVE_XACT_SQL)
-                rows = cur.fetchall()
-            except psycopg.Error:
-                rows = []
+            rows = self._tick_query(conn, cur, _ACTIVE_XACT_SQL, fetchall=True) or []
             self._emit(
                 subject_kind="cluster",
                 subject="",

--- a/bench_harness/metrics.py
+++ b/bench_harness/metrics.py
@@ -101,6 +101,32 @@ SELECT
 FROM pg_stat_wal
 """
 
+# Per-relation on-disk file identity. A change to relfilenode between ticks is
+# the exact signature of a non-concurrent TRUNCATE / VACUUM FULL / CLUSTER /
+# REINDEX / rewriting ALTER — i.e. the destructive DDL an idle queue's segment
+# reclaim leans on. Diffing this needs no extension (unlike pg_stat_statements,
+# which is not preloaded here), so it works uniformly across every engine.
+_RELFILENODE_SQL = """
+SELECT n.nspname || '.' || c.relname AS relation, c.relfilenode::text
+FROM pg_class c
+JOIN pg_namespace n ON n.oid = c.relnamespace
+WHERE c.relkind IN ('r', 'i', 't', 'm')
+  AND n.nspname NOT IN ('pg_catalog', 'information_schema', 'pg_toast')
+  AND c.relfilenode <> 0
+"""
+
+# Per-database transaction / tuple churn. With offered load driven to zero,
+# this measures how chatty each engine's background loop is (leader election,
+# heartbeat, ring rotation, archive sweeps). Built-in view, no extension.
+_PG_STAT_DATABASE_SQL = """
+SELECT
+  (xact_commit + xact_rollback)::double precision AS xacts,
+  tup_updated::double precision,
+  tup_deleted::double precision
+FROM pg_stat_database
+WHERE datname = current_database()
+"""
+
 _ACTIVE_XACT_SQL = """
 SELECT
   pid,
@@ -211,6 +237,11 @@ class MetricsDaemon(threading.Thread):
         # aggregations key on exact elapsed_s equality.
         self._tick_elapsed_s: float | None = None
         self._tick_sampled_at: str | None = None
+        # Relfilenode-churn tracking. Lives for the whole run (per-system
+        # daemon), so relfilenode_churn_total is monotonic across phases and
+        # its per-phase delta drops out of the existing counter-delta path.
+        self._relfilenode_prev: dict[str, str] = {}
+        self._relfilenode_churn_total = 0
 
     # ── one-shot boundary snapshots ─────────────────────────────────────
     def phase_boundary_snapshot(self) -> None:
@@ -512,6 +543,57 @@ class MetricsDaemon(threading.Thread):
                     subject="",
                     metric="pg_wal_bytes",
                     value=float(wal_bytes),
+                )
+
+            # Relfilenode churn: diff this tick's file identities against the
+            # previous tick and accumulate the number of relations that were
+            # swapped (TRUNCATE / VACUUM FULL / REINDEX / rewrite). Emitted as
+            # a monotonic cluster counter so the per-phase delta and rate fall
+            # out of the standard counter-delta aggregation.
+            try:
+                cur.execute(_RELFILENODE_SQL)
+                current = {rel: node for rel, node in cur.fetchall()}
+            except psycopg.Error:
+                current = None
+            if current is not None:
+                if self._relfilenode_prev:
+                    for rel, node in current.items():
+                        prev = self._relfilenode_prev.get(rel)
+                        if prev is not None and prev != node:
+                            self._relfilenode_churn_total += 1
+                self._relfilenode_prev = current
+                self._emit(
+                    subject_kind="cluster",
+                    subject="",
+                    metric="relfilenode_churn_total",
+                    value=float(self._relfilenode_churn_total),
+                )
+
+            # Per-database transaction / tuple churn (background chattiness).
+            try:
+                cur.execute(_PG_STAT_DATABASE_SQL)
+                row = cur.fetchone()
+            except psycopg.Error:
+                row = None
+            if row is not None:
+                db_xacts, db_tup_updated, db_tup_deleted = row
+                self._emit(
+                    subject_kind="cluster",
+                    subject="",
+                    metric="pg_db_xacts_total",
+                    value=float(db_xacts),
+                )
+                self._emit(
+                    subject_kind="cluster",
+                    subject="",
+                    metric="pg_db_tup_updated_total",
+                    value=float(db_tup_updated),
+                )
+                self._emit(
+                    subject_kind="cluster",
+                    subject="",
+                    metric="pg_db_tup_deleted_total",
+                    value=float(db_tup_deleted),
                 )
 
             try:

--- a/bench_harness/orchestrator.py
+++ b/bench_harness/orchestrator.py
@@ -30,8 +30,9 @@ from . import adapters as adapters_mod
 from . import writers as writers_mod
 from .adapters import (
     ADAPTERS,
-    DEFAULT_PG_IMAGE,
+    DEFAULT_ENGINE,
     DEFAULT_SYSTEMS,
+    ENGINES,
     AdapterEntry,
     AdapterManifest,
     pg_url,
@@ -110,25 +111,33 @@ def _compose_env(pg_image: str) -> dict[str, str]:
     return {"POSTGRES_IMAGE": pg_image}
 
 
-def start_postgres(pg_image: str) -> None:
+def _compose_prefix(engine: str) -> list[str]:
+    """`docker compose` argv prefix for an engine.
+
+    For the default engine (no override) we emit a bare ``docker compose``
+    so the implicit ``docker-compose.override.yml`` auto-merge is preserved
+    (the tuning-matrix workflow relies on it). For an engine with an
+    override we pass explicit ``-f`` files — which also disables the
+    implicit merge, giving a reproducible, engine-pinned compose project.
+    """
+    override = ENGINES[engine].compose_override if engine in ENGINES else None
+    if override is None:
+        return ["docker", "compose"]
+    return ["docker", "compose", "-f", "docker-compose.yml", "-f", override]
+
+
+def start_postgres(pg_image: str, engine: str = DEFAULT_ENGINE) -> None:
+    prefix = _compose_prefix(engine)
     _run_cmd(
-        ["docker", "compose", "up", "-d", "--wait"],
+        [*prefix, "up", "-d", "--wait"],
         cwd=SCRIPT_DIR,
         env=_compose_env(pg_image),
     )
-    # Readiness probe
-    for _ in range(30):
+    # Readiness probe. Omni initdb + engine bring-up is slower than the
+    # alpine image, so allow a generous window.
+    for _ in range(60):
         r = subprocess.run(
-            [
-                "docker",
-                "compose",
-                "exec",
-                "-T",
-                "postgres",
-                "pg_isready",
-                "-U",
-                "bench",
-            ],
+            [*prefix, "exec", "-T", "postgres", "pg_isready", "-U", "bench"],
             cwd=str(SCRIPT_DIR),
             env={**os.environ, **_compose_env(pg_image)},
             capture_output=True,
@@ -155,36 +164,34 @@ def start_postgres(pg_image: str) -> None:
     )
 
 
-def _compose_stop_postgres(pg_image: str) -> None:
+def _compose_stop_postgres(pg_image: str, engine: str = DEFAULT_ENGINE) -> None:
     """Stop (but don't remove) the postgres container — used by the
     `postgres-restart` chaos phase to take PG down mid-run without
     blowing away the volume the system-under-test is talking to."""
     _run_cmd(
-        ["docker", "compose", "stop", "postgres"],
+        [*_compose_prefix(engine), "stop", "postgres"],
         cwd=SCRIPT_DIR,
         env=_compose_env(pg_image),
         check=False,
     )
 
 
-def _compose_start_postgres(pg_image: str) -> None:
+def _compose_start_postgres(pg_image: str, engine: str = DEFAULT_ENGINE) -> None:
     """Start the existing postgres container and wait for readiness.
 
     Re-uses the same readiness probe as ``start_postgres`` so callers
     that bring PG back up after a chaos `stop` get the same guarantees
     (pg_isready + a real SELECT 1 round-trip).
     """
+    prefix = _compose_prefix(engine)
     _run_cmd(
-        ["docker", "compose", "start", "postgres"],
+        [*prefix, "start", "postgres"],
         cwd=SCRIPT_DIR,
         env=_compose_env(pg_image),
     )
     for _ in range(60):
         r = subprocess.run(
-            [
-                "docker", "compose", "exec", "-T", "postgres",
-                "pg_isready", "-U", "bench",
-            ],
+            [*prefix, "exec", "-T", "postgres", "pg_isready", "-U", "bench"],
             cwd=str(SCRIPT_DIR),
             env={**os.environ, **_compose_env(pg_image)},
             capture_output=True,
@@ -210,20 +217,20 @@ def _compose_start_postgres(pg_image: str) -> None:
     )
 
 
-def _restart_postgres(pg_image: str) -> None:
+def _restart_postgres(pg_image: str, engine: str = DEFAULT_ENGINE) -> None:
     """Stop + start the postgres container. Bound into runtime.state by
     the orchestrator so the postgres-restart phase hook doesn't need to
     know about compose at all."""
-    _compose_stop_postgres(pg_image)
-    _compose_start_postgres(pg_image)
+    _compose_stop_postgres(pg_image, engine)
+    _compose_start_postgres(pg_image, engine)
 
 
-def stop_postgres(pg_image: str) -> None:
+def stop_postgres(pg_image: str, engine: str = DEFAULT_ENGINE) -> None:
     if os.environ.get("KEEP_DB"):
         print("[harness] KEEP_DB set — leaving postgres running for inspection")
         return
     _run_cmd(
-        ["docker", "compose", "down", "-v"],
+        [*_compose_prefix(engine), "down", "-v"],
         cwd=SCRIPT_DIR,
         env=_compose_env(pg_image),
         check=False,
@@ -660,6 +667,7 @@ def run_one_system(
     *,
     phases: list[Phase],
     pg_image: str,
+    engine: str = DEFAULT_ENGINE,
     fast: bool,
     run_id: str,
     out_queue: "queue.Queue[Sample]",
@@ -690,8 +698,8 @@ def run_one_system(
 
     # Sequential per-system fresh-PG isolation is the default.
     if not fast:
-        stop_postgres(pg_image)
-        start_postgres(pg_image)
+        stop_postgres(pg_image, engine)
+        start_postgres(pg_image, engine)
 
     preflight_database(manifest, recreate=fast)
 
@@ -785,9 +793,9 @@ def run_one_system(
         # restart) and know where to wait afterwards. Stash a no-arg
         # restart callback + URL probe instead of leaking compose
         # internals into the hooks module.
-        "postgres_restart_fn": lambda: _restart_postgres(pg_image),
-        "postgres_stop_fn": lambda: _compose_stop_postgres(pg_image),
-        "postgres_start_fn": lambda: _compose_start_postgres(pg_image),
+        "postgres_restart_fn": lambda: _restart_postgres(pg_image, engine),
+        "postgres_stop_fn": lambda: _compose_stop_postgres(pg_image, engine),
+        "postgres_start_fn": lambda: _compose_start_postgres(pg_image, engine),
         "admin_database_url": pg_url("postgres"),
         "system_database_url": pg_url(manifest.db_name),
         "system_database_name": manifest.db_name,
@@ -871,10 +879,15 @@ def _sleep_or_abort(seconds: float, pool: ReplicaPool) -> None:
 # ────────────────────────────────────────────────────────────────────────
 
 
-def _new_run_dir(scenario: str | None) -> Path:
+def _new_run_dir(scenario: str | None, engine: str = DEFAULT_ENGINE) -> Path:
     ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
     short_id = uuid.uuid4().hex[:6]
-    name = f"{scenario or 'custom'}-{ts}-{short_id}"
+    # Fold a non-default engine into the run-id so an Omni run is never
+    # confused with a postgres run. Gated on non-default so the postgres
+    # `custom-…` / `<scenario>-…` prefix stays byte-identical and existing
+    # tooling regexes (scripts/run_full_sweep.sh) keep matching.
+    engine_tag = "" if engine == DEFAULT_ENGINE else f"-{engine}"
+    name = f"{scenario or 'custom'}{engine_tag}-{ts}-{short_id}"
     run_dir = RESULTS_ROOT / name
     run_dir.mkdir(parents=True, exist_ok=True)
     return run_dir
@@ -886,6 +899,7 @@ def drive(
     scenario: str | None,
     phases: list[Phase],
     pg_image: str,
+    engine: str = DEFAULT_ENGINE,
     fast: bool,
     skip_build: bool,
     sample_every_s: int,
@@ -904,7 +918,7 @@ def drive(
     if unknown:
         raise SystemExit(f"Unknown systems: {unknown}. Known: {sorted(ADAPTERS)}")
 
-    run_dir = _new_run_dir(scenario)
+    run_dir = _new_run_dir(scenario, engine)
     run_id = run_dir.name
     print(f"[harness] run_id = {run_id}", file=sys.stderr)
     raw_csv = run_dir / "raw.csv"
@@ -927,7 +941,7 @@ def drive(
     try:
         # Start PG once upfront (needed for the initial build phase to connect;
         # also the --fast path keeps this same instance across systems).
-        start_postgres(pg_image)
+        start_postgres(pg_image, engine)
 
         if not skip_build:
             for system in systems:
@@ -965,6 +979,7 @@ def drive(
                     s: adapter_descriptors[s] for s in completed_systems
                 },
                 pg_image=pg_image,
+                engine=engine,
             )
             if pg_env_snapshot:
                 ckpt_manifest["postgres"] = pg_env_snapshot
@@ -981,6 +996,7 @@ def drive(
                 system,
                 phases=phases,
                 pg_image=pg_image,
+                engine=engine,
                 fast=fast,
                 run_id=run_id,
                 out_queue=out_queue,
@@ -1023,7 +1039,7 @@ def drive(
         drain_stop.set()
         drain_thread.join(timeout=10)
         writer.close()
-        stop_postgres(pg_image)
+        stop_postgres(pg_image, engine)
 
     # Final post-processing outputs. Recompute against the full
     # `completed` list to pick up any drain-loop samples that landed
@@ -1097,9 +1113,18 @@ def _add_run_arguments(parser: argparse.ArgumentParser) -> None:
         "because it duplicates the awa-native line in cross-system plots.",
     )
     parser.add_argument(
+        "--engine",
+        default=DEFAULT_ENGINE,
+        choices=sorted(ENGINES),
+        help="Storage engine to benchmark on (default: postgres). "
+        "'alloydb-omni' runs the same major on AlloyDB Omni via a compose "
+        "override that preserves the columnar/storage engine preload.",
+    )
+    parser.add_argument(
         "--pg-image",
-        default=DEFAULT_PG_IMAGE,
-        help="Pinned Postgres image. Do not track a moving major tag.",
+        default=None,
+        help="Override the engine's default Postgres image. Do not track a "
+        "moving major tag. Defaults to the selected --engine's image.",
     )
     parser.add_argument(
         "--fast",
@@ -1259,6 +1284,7 @@ def _cmd_run(args: argparse.Namespace) -> int:
         scenario=config.scenario,
         phases=phases,
         pg_image=config.pg_image,
+        engine=config.engine,
         fast=config.fast,
         skip_build=config.skip_build,
         sample_every_s=config.sample_every,

--- a/bench_harness/phases.py
+++ b/bench_harness/phases.py
@@ -18,6 +18,11 @@ class PhaseType(str, Enum):
     WARMUP = "warmup"
     CLEAN = "clean"
     IDLE_IN_TX = "idle-in-tx"
+    # Near-zero offered load with the worker/maintenance runtime still
+    # running — measures the queue engine's OWN background cost (WAL,
+    # destructive-DDL churn, background xacts). Distinct from idle-in-tx,
+    # which holds a transaction open to pin the vacuum horizon under load.
+    IDLE_BACKGROUND = "idle-background"
     RECOVERY = "recovery"
     ACTIVE_READERS = "active-readers"
     HIGH_LOAD = "high-load"
@@ -37,6 +42,7 @@ PHASE_TINTS: dict[PhaseType, tuple[str, float]] = {
     PhaseType.WARMUP:          ("#D0D0D0", 0.40),
     PhaseType.CLEAN:           ("#B8B8B8", 0.35),
     PhaseType.IDLE_IN_TX:      ("#D46A6A", 0.30),
+    PhaseType.IDLE_BACKGROUND: ("#6C8EBF", 0.25),
     PhaseType.RECOVERY:        ("#DCDCDC", 0.30),
     PhaseType.ACTIVE_READERS:  ("#E0B66C", 0.30),
     PhaseType.HIGH_LOAD:       ("#A378C8", 0.30),
@@ -57,6 +63,7 @@ PHASE_INCLUDED_IN_SUMMARY: dict[PhaseType, bool] = {
     PhaseType.WARMUP:          False,
     PhaseType.CLEAN:           True,
     PhaseType.IDLE_IN_TX:      True,
+    PhaseType.IDLE_BACKGROUND: True,
     PhaseType.RECOVERY:        True,
     PhaseType.ACTIVE_READERS:  True,
     PhaseType.HIGH_LOAD:       True,
@@ -196,6 +203,16 @@ def parse_phase_spec(spec: str) -> Phase:
 
 # Named scenarios desugar into explicit phase lists.
 SCENARIOS: dict[str, list[str]] = {
+    # Idle / low-throughput background cost. Invoke with --producer-rate 0
+    # (or a small trickle): the worker/maintenance runtime keeps ticking
+    # while ~no jobs are offered, so the Postgres-side metrics (WAL bytes/s,
+    # relfilenode/TRUNCATE churn, background xacts) isolate the queue
+    # engine's own maintenance cost. Contrast idle_in_tx_saturation, which
+    # pins the xmin horizon under load.
+    "idle_background_cost": [
+        "warmup=warmup:2m",
+        "idle_1=idle-background:60m",
+    ],
     "idle_in_tx_saturation": [
         "warmup=warmup:10m",
         "clean_1=clean:60m",

--- a/bench_harness/plots.py
+++ b/bench_harness/plots.py
@@ -96,6 +96,23 @@ PLOT_SPECS: dict[str, PlotSpec] = {
         use_raw_underlay=True,
         subject_kind="table",
     ),
+    # Idle background-cost signals (cluster-scoped, single subject).
+    "pg_wal_bytes": PlotSpec(
+        title="WAL bytes (cumulative)",
+        filename_stem="wal_bytes",
+        y_label="pg_stat_wal.wal_bytes (cumulative)",
+        use_raw_underlay=True,
+        subject_kind="cluster",
+        sum_by_subject=False,
+    ),
+    "relfilenode_churn_total": PlotSpec(
+        title="Relfilenode churn (cumulative TRUNCATE/rewrite)",
+        filename_stem="relfilenode_churn",
+        y_label="relfilenode changes (cumulative)",
+        use_raw_underlay=True,
+        subject_kind="cluster",
+        sum_by_subject=False,
+    ),
     "claim_p99_ms": PlotSpec(
         title="Claim p99 latency",
         filename_stem="claim_p99",

--- a/bench_harness/report.py
+++ b/bench_harness/report.py
@@ -35,6 +35,11 @@ DEFAULT_TIMELINE_METRICS = [
     "scheduled_depth",
     "total_backlog",
     "n_dead_tup",
+    # Idle background-cost (cluster-scoped). Surfaced so the
+    # idle_background_cost scenario's headline signals are explorable.
+    "pg_wal_bytes",
+    "relfilenode_churn_total",
+    "pg_db_xacts_total",
 ]
 
 DEFAULT_PHASE_FILTER = "steady"
@@ -56,6 +61,9 @@ METRIC_LABELS = {
     "scheduled_depth": "Scheduled backlog",
     "total_backlog": "Total backlog",
     "n_dead_tup": "Dead tuples",
+    "pg_wal_bytes": "WAL bytes (cumulative)",
+    "relfilenode_churn_total": "Relfilenode churn (cumulative TRUNCATE/rewrite)",
+    "pg_db_xacts_total": "Background transactions (cumulative)",
 }
 
 TIMELINE_PRESETS = [
@@ -77,6 +85,8 @@ PLOT_ORDER = [
     "dead_tuples",
     "dead_tuples_faceted",
     "table_size",
+    "wal_bytes",
+    "relfilenode_churn",
     # Wait-event histogram per system (clean phase). Only rendered if any
     # wait-event rows landed in raw.csv; the report's existence-check on
     # the SVG file means this naturally degrades when --no-wait-events

--- a/bench_harness/writers.py
+++ b/bench_harness/writers.py
@@ -546,6 +546,38 @@ def compute_summary(
                 phase_label=phase_label,
                 metric="pg_wal_fpi",
             )
+            # Idle background-cost rates. Normalize the monotonic-counter
+            # deltas by the phase duration so WAL/DDL/xact cost is comparable
+            # across engines and queues regardless of phase length. These are
+            # the headline numbers for the idle_background_cost scenario.
+            _phase = phase_by_label.get(phase_label)
+            _dur = float(_phase.duration_s) if _phase is not None else 0.0
+            _wal_delta = phase_block["pg_wal_bytes_delta"]
+            phase_block["pg_wal_bytes_per_s"] = (
+                _wal_delta / _dur
+                if (_wal_delta is not None and _dur > 0)
+                else None
+            )
+            phase_block["relfilenode_churn_delta"] = _cluster_counter_delta(
+                rows,
+                system=system,
+                phase_label=phase_label,
+                metric="relfilenode_churn_total",
+            )
+            _churn = phase_block["relfilenode_churn_delta"]
+            phase_block["relfilenode_churn_per_s"] = (
+                _churn / _dur if (_churn is not None and _dur > 0) else None
+            )
+            phase_block["pg_db_xacts_delta"] = _cluster_counter_delta(
+                rows,
+                system=system,
+                phase_label=phase_label,
+                metric="pg_db_xacts_total",
+            )
+            _xacts = phase_block["pg_db_xacts_delta"]
+            phase_block["pg_db_xacts_per_s"] = (
+                _xacts / _dur if (_xacts is not None and _dur > 0) else None
+            )
             phase_block["replicas"] = replicas
             wait = _wait_event_summary(
                 rows, system=system, phase_label=phase_label
@@ -963,6 +995,10 @@ def capture_pg_env(database_url: str) -> dict:
         "max_connections",
         "synchronous_commit",
         "wal_level",
+        # The single check that proves a non-postgres engine (e.g. AlloyDB
+        # Omni) actually loaded its engine libs rather than running as
+        # plain Postgres in an engine-tagged image.
+        "shared_preload_libraries",
     ]
     try:
         with psycopg.connect(database_url, autocommit=True) as conn:
@@ -1015,6 +1051,7 @@ def build_manifest(
     cli_args: list[str],
     adapter_versions: dict[str, dict],
     pg_image: str,
+    engine: str = "postgres",
 ) -> dict:
     return {
         "run_id": run_id,
@@ -1026,6 +1063,7 @@ def build_manifest(
             {"label": p.label, "type": p.type.value, "duration_s": p.duration_s}
             for p in phases
         ],
+        "engine": engine,
         "pg_image": pg_image,
         "postgres": capture_pg_env(database_url) if database_url else None,
         "host": capture_host_env(),

--- a/bench_harness/writers.py
+++ b/bench_harness/writers.py
@@ -547,16 +547,16 @@ def compute_summary(
                 metric="pg_wal_fpi",
             )
             # Idle background-cost rates. Normalize the monotonic-counter
-            # deltas by the phase duration so WAL/DDL/xact cost is comparable
-            # across engines and queues regardless of phase length. These are
-            # the headline numbers for the idle_background_cost scenario.
-            _phase = phase_by_label.get(phase_label)
-            _dur = float(_phase.duration_s) if _phase is not None else 0.0
-            _wal_delta = phase_block["pg_wal_bytes_delta"]
-            phase_block["pg_wal_bytes_per_s"] = (
-                _wal_delta / _dur
-                if (_wal_delta is not None and _dur > 0)
-                else None
+            # deltas by the OBSERVED sample span (not the configured phase
+            # duration, which overstates the denominator when a phase is cut
+            # short) so WAL/DDL/xact cost is comparable across engines and
+            # queues regardless of phase length. These are the headline
+            # numbers for the idle_background_cost scenario.
+            phase_block["pg_wal_bytes_per_s"] = _cluster_counter_rate(
+                rows,
+                system=system,
+                phase_label=phase_label,
+                metric="pg_wal_bytes",
             )
             phase_block["relfilenode_churn_delta"] = _cluster_counter_delta(
                 rows,
@@ -564,9 +564,11 @@ def compute_summary(
                 phase_label=phase_label,
                 metric="relfilenode_churn_total",
             )
-            _churn = phase_block["relfilenode_churn_delta"]
-            phase_block["relfilenode_churn_per_s"] = (
-                _churn / _dur if (_churn is not None and _dur > 0) else None
+            phase_block["relfilenode_churn_per_s"] = _cluster_counter_rate(
+                rows,
+                system=system,
+                phase_label=phase_label,
+                metric="relfilenode_churn_total",
             )
             phase_block["pg_db_xacts_delta"] = _cluster_counter_delta(
                 rows,
@@ -574,9 +576,11 @@ def compute_summary(
                 phase_label=phase_label,
                 metric="pg_db_xacts_total",
             )
-            _xacts = phase_block["pg_db_xacts_delta"]
-            phase_block["pg_db_xacts_per_s"] = (
-                _xacts / _dur if (_xacts is not None and _dur > 0) else None
+            phase_block["pg_db_xacts_per_s"] = _cluster_counter_rate(
+                rows,
+                system=system,
+                phase_label=phase_label,
+                metric="pg_db_xacts_total",
             )
             phase_block["replicas"] = replicas
             wait = _wait_event_summary(
@@ -951,6 +955,40 @@ def _cluster_counter_delta(
     # pg_stat_wal counters are monotonically non-decreasing. Use max-min so
     # queue drain ordering cannot make the delta negative.
     return float(max(values) - min(values))
+
+
+def _cluster_counter_rate(
+    rows: list[dict], *, system: str, phase_label: str, metric: str
+) -> float | None:
+    """Per-second rate of a monotonic cluster counter over one phase.
+
+    The denominator is the observed span between the metric's first and
+    last samples in the phase — not the configured phase duration, which
+    overstates the denominator (understating the rate) when a phase is
+    interrupted or a daemon starts late.
+    """
+    points: list[tuple[float, float]] = []
+    for row in rows:
+        if (
+            row["system"] != system
+            or row["phase_label"] != phase_label
+            or row["metric"] != metric
+            or row["subject_kind"] != "cluster"
+        ):
+            continue
+        try:
+            points.append((float(row["elapsed_s"]), float(row["value"])))
+        except (TypeError, ValueError):
+            continue
+    if len(points) < 2:
+        return None
+    points.sort()
+    span_s = points[-1][0] - points[0][0]
+    if span_s <= 0:
+        return None
+    values = [value for _, value in points]
+    # Same max-min convention as _cluster_counter_delta (monotonic counter).
+    return (max(values) - min(values)) / span_s
 
 
 def write_summary(summary: dict, path: Path) -> None:

--- a/docker-compose.omni.override.yml
+++ b/docker-compose.omni.override.yml
@@ -11,9 +11,13 @@
 # the command line wins cleanly while keeping postgres.conf byte-identical
 # across engines (fair-comparison GUCs preserved). The list was captured from
 # the stock image via `SHOW shared_preload_libraries`.
+# The env-substituted image keeps `--pg-image` working on this engine (the
+# harness always sets POSTGRES_IMAGE, resolved from --engine unless
+# overridden); a literal image here would win the compose merge over the base
+# file's ${POSTGRES_IMAGE} and silently ignore the flag.
 services:
   postgres:
-    image: gcr.io/alloydb-omni/alloydbomni:18.3
+    image: ${POSTGRES_IMAGE:-gcr.io/alloydb-omni/alloydbomni:18.3}
     command:
       - "postgres"
       - "-c"

--- a/docker-compose.omni.override.yml
+++ b/docker-compose.omni.override.yml
@@ -1,0 +1,27 @@
+# AlloyDB Omni engine override. Merged via `-f` ONLY for `--engine alloydb-omni`
+# (see bench_harness/adapters.py ENGINES); it is deliberately NOT named
+# docker-compose.override.yml so it cannot leak into stock-postgres runs.
+#
+# Why the explicit shared_preload_libraries: the base docker-compose.yml pins
+# `command: postgres -c config_file=/etc/postgresql/postgresql.conf`, which
+# makes the server read the harness's postgres.conf as its base config instead
+# of Omni's generated one — bypassing Omni's preload line and silently
+# disabling the columnar/storage engine (you'd benchmark plain PG in an Omni
+# tag). postgres.conf sets no shared_preload_libraries, so re-adding it here on
+# the command line wins cleanly while keeping postgres.conf byte-identical
+# across engines (fair-comparison GUCs preserved). The list was captured from
+# the stock image via `SHOW shared_preload_libraries`.
+services:
+  postgres:
+    image: gcr.io/alloydb-omni/alloydbomni:18.3
+    command:
+      - "postgres"
+      - "-c"
+      - "config_file=/etc/postgresql/postgresql.conf"
+      - "-c"
+      - "shared_preload_libraries=g_stats,google_columnar_engine,google_job_scheduler,google_ml_integration,google_storage"
+    deploy:
+      resources:
+        limits:
+          # Omni's engine is heavier than postgres:alpine; 8G can be tight.
+          memory: 12G


### PR DESCRIPTION
Closes #41.

Adds two additive capabilities so the harness can measure a queue's **own background maintenance cost on a different storage engine** — the class of regression it couldn't see before (idle background cost, on stock Postgres only).

## 1. AlloyDB Omni engine axis
- `--engine {postgres,alloydb-omni}` + an `ENGINES` registry (default `postgres`; `--pg-image` still overrides the image).
- New `docker-compose.omni.override.yml`, merged via `-f` **only** for `--engine alloydb-omni` (distinct name so it can't leak into postgres runs). It re-adds Omni's real preload (`g_stats,google_columnar_engine,google_job_scheduler,google_ml_integration,google_storage`) on the command line — the base compose's `-c config_file=…` would otherwise bypass Omni's generated preload and silently disable the engine (plain PG in an Omni tag). Default postgres runs keep a bare `docker compose` so the implicit `docker-compose.override.yml` auto-merge (tuning matrix) is preserved.
- `engine` recorded in `manifest.json` and folded into the run-id (gated on non-default so existing tooling regexes still match); `capture_pg_env` now records `shared_preload_libraries` — the single check that proves a faithful Omni run.
- No adapter changes (they see only `DATABASE_URL`); `init-databases.sql`/`pgstattuple` work on Omni; readiness probe widened for Omni's slower boot.

## 2. `idle_background_cost` scenario
Run at `--producer-rate 0` (workers/maintenance keep ticking; every adapter already honors rate 0). New phase type `idle-background`. Three new metrics, all **Postgres-side and extension-free** (fair across every adapter, zero adapter cooperation):
- **relfilenode churn** — diff `pg_class.relfilenode` per tick; a change is the exact on-disk signature of a non-concurrent `TRUNCATE`/`VACUUM FULL`/`REINDEX`/rewrite (so "an idle ring re-TRUNCATEs empty slots every tick" shows up directly).
- **`pg_stat_database` xact/tuple counters** — background chattiness.
- **WAL bytes/sec** — derived from the existing `pg_stat_wal` per-phase delta.

Surfaced in `summary.json` (per-second rates), the report timeline + plots, and a new "Idle background cost" section in `COMPARISON.md`.

## Motivation
A production incident traced a large AlloyDB p99/IO-wait spike on unrelated queries to a job queue's background `TRUNCATE`-based segment reclaim running every tick with **zero jobs enqueued** — cheap on local-SSD PG, costly on AlloyDB's storage engine, worst at low throughput. See #41.

## Testing
- `uv run pytest` — **107 passed** (auto-parametrized scenario/phase smoke now covers `idle_background_cost` + `idle-background`).
- **Live Omni 18.3 boot** with the override: server starts, `shared_preload_libraries` shows the columnar engine, harness `postgres.conf` GUCs applied (`shared_buffers=256MB` etc.), `google_columnar_engine` extension present. (`alloydbadmin does not exist` appears in Omni's log — its internal admin-agent connection, benign to the benchmark.)
- **New metric SQL on live Omni**: `pg_stat_database` counters return; `TRUNCATE` changes the relfilenode (churn-detection premise holds on the real engine).
- **Live end-to-end** (postgres engine, procrastinate, `--producer-rate 0`, short phases): `raw.csv` carries all new metrics; `summary.json` idle phase shows `pg_wal_bytes_per_s=1675`, `relfilenode_churn_per_s=0` (procrastinate doesn't TRUNCATE idle — correct), `pg_db_xacts_per_s=44.7`; `manifest.engine=postgres`.

## Fidelity note
Single-container Omni reproduces the **engine/storage-AM** cost (config/version-independent), not managed AlloyDB's disaggregated-storage latency (which layers on top) — a cheap, reproducible proxy needing no managed instance.

## Follow-ups (not in this PR)
- A full engine×system sweep on the Omni axis for the results set.
- Optionally create the `alloydbadmin` DB on the Omni path to quiet its admin-agent log line.
